### PR TITLE
CHB-46 part 2: NFJ 429 too many request on low performance

### DIFF
--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/NfjJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/NfjJobPublisher.java
@@ -15,11 +15,15 @@ public class NfjJobPublisher {
     private static final String SOURCE_NOFLUFF = "NOFLUFFJOBS";
 
     public void publishUrl(String url) {
-        publishUrl(url, SOURCE_NOFLUFF);
+        publishUrl(url, SOURCE_NOFLUFF, null);
     }
 
     public void publishUrl(String url, String source) {
-        UrlMessage msg = new UrlMessage(url, source);
+        publishUrl(url, source, null);
+    }
+
+    public void publishUrl(String url, String source, String externalId) {
+        UrlMessage msg = new UrlMessage(url, source, externalId);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/SolidJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/SolidJobPublisher.java
@@ -15,7 +15,7 @@ public class SolidJobPublisher {
     private static final String SOURCE_SOLID = "SOLIDJOBS";
 
     public void publishUrl(String url) {
-        UrlMessage msg = new UrlMessage(url, SOURCE_SOLID);
+        UrlMessage msg = new UrlMessage(url, SOURCE_SOLID, null);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/TheProtocolJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/TheProtocolJobPublisher.java
@@ -15,7 +15,7 @@ public class TheProtocolJobPublisher {
     private static final String SOURCE_THEPROTOCOL = "THEPROTOCOL";
 
     public void publishUrl(String url) {
-        UrlMessage msg = new UrlMessage(url, SOURCE_THEPROTOCOL);
+        UrlMessage msg = new UrlMessage(url, SOURCE_THEPROTOCOL, null);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/UrlMessage.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/UrlMessage.java
@@ -2,5 +2,6 @@ package com.milosz.podsiadly.careerhub.agentcrawler.mq;
 
 public record UrlMessage(
         String url,
-        String source
+        String source,
+        String externalId
 ) {}

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/NfjCrawlerScheduler.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/NfjCrawlerScheduler.java
@@ -7,7 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -54,25 +56,25 @@ public class NfjCrawlerScheduler {
 
     private void runOnce() {
         try {
-            Set<String> allUrls = new LinkedHashSet<>();
+            Map<String, String> allRefs = new LinkedHashMap<>();
 
             Set<String> seenIdsThisRun = new LinkedHashSet<>();
 
             for (String slug : NFJ_CATEGORY_SLUGS) {
                 log.info("[agent-nfj] crawling category slug={} (NFJ /pl/{})", slug, slug);
 
-                Set<String> slice = apiClient.fetchAllJobUrls(slug, seenIdsThisRun);
+                Map<String, String> slice = apiClient.fetchAllJobRefs(slug, seenIdsThisRun);
 
                 log.info("[agent-nfj] slug={} got {} urls (after id-dedupe, before merge)", slug, slice.size());
 
-                allUrls.addAll(slice);
+                allRefs.putAll(slice);
             }
 
-            log.info("[agent-nfj] NFJ merged unique urls across all slugs={}", allUrls.size());
+            log.info("[agent-nfj] NFJ merged unique urls across all slugs={}", allRefs.size());
 
             int sentThisRun = 0;
-            for (String url : allUrls) {
-                publisher.publishUrl(url);
+            for (Map.Entry<String, String> entry : allRefs.entrySet()) {
+                publisher.publishUrl(entry.getValue(), "NOFLUFFJOBS", entry.getKey());
                 sentThisRun++;
             }
 

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/api/NfjApiClient.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/api/NfjApiClient.java
@@ -15,7 +15,9 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -37,11 +39,15 @@ public class NfjApiClient {
     private final RestTemplate restTemplate;
 
     public Set<String> fetchAllJobUrls(String categorySlug) {
-        return fetchAllJobUrls(categorySlug, new LinkedHashSet<>());
+        return new LinkedHashSet<>(fetchAllJobRefs(categorySlug, new LinkedHashSet<>()).values());
     }
 
     public Set<String> fetchAllJobUrls(String categorySlug, Set<String> seenIdsThisRun) {
-        Set<String> urls = new LinkedHashSet<>();
+        return new LinkedHashSet<>(fetchAllJobRefs(categorySlug, seenIdsThisRun).values());
+    }
+
+    public Map<String, String> fetchAllJobRefs(String categorySlug, Set<String> seenIdsThisRun) {
+        Map<String, String> refs = new LinkedHashMap<>();
 
         int pageTo = 0;
         int totalPages = 1;
@@ -71,11 +77,11 @@ public class NfjApiClient {
                 }
 
                 String abs = "https://nofluffjobs.com/pl/job/" + url;
-                urls.add(abs);
+                refs.put(id, abs);
             });
 
             log.info("[nfj-api] page={} collected so far={} (category={})",
-                    pageTo, urls.size(), categorySlug);
+                    pageTo, refs.size(), categorySlug);
 
             if (response.getTotalPages() > 0) {
                 totalPages = response.getTotalPages();
@@ -83,8 +89,8 @@ public class NfjApiClient {
             pageTo++;
         }
 
-        log.info("[nfj-api] DONE: total unique urls={} (category={})", urls.size(), categorySlug);
-        return urls;
+        log.info("[nfj-api] DONE: total unique urls={} (category={})", refs.size(), categorySlug);
+        return refs;
     }
 
     private NfjSearchResponse fetchPage(String categorySlug, int pageTo, int pageSize) {

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/SilentAmqpErrorHandler.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/SilentAmqpErrorHandler.java
@@ -12,17 +12,19 @@ final class SilentAmqpErrorHandler implements ErrorHandler {
 
     @Override
     public void handleError(Throwable t) {
+        Throwable delayed = findCause(t, DelayedRetryException.class);
+        if (delayed instanceof DelayedRetryException retry) {
+            log.debug("[amqp] delayed retry: {}", retry.getMessage());
+            return;
+        }
+
+        Throwable drop = findCause(t, AmqpRejectAndDontRequeueException.class);
+        if (drop instanceof AmqpRejectAndDontRequeueException reject) {
+            log.debug("[amqp] drop: {}", reject.getMessage());
+            return;
+        }
+
         Throwable root = unwrap(t);
-
-        if (root instanceof DelayedRetryException) {
-            log.debug("[amqp] delayed retry: {}", root.getMessage());
-            return;
-        }
-        if (root instanceof AmqpRejectAndDontRequeueException) {
-            log.debug("[amqp] drop: {}", root.getMessage());
-            return;
-        }
-
         log.warn("[amqp] listener error: {}", root.toString());
     }
 
@@ -30,5 +32,15 @@ final class SilentAmqpErrorHandler implements ErrorHandler {
         Throwable x = t;
         while (x.getCause() != null && x.getCause() != x) x = x.getCause();
         return x;
+    }
+
+    private static <T extends Throwable> T findCause(Throwable t, Class<T> type) {
+        Throwable x = t;
+        while (x != null) {
+            if (type.isInstance(x)) return type.cast(x);
+            if (x.getCause() == x) break;
+            x = x.getCause();
+        }
+        return null;
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumeService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumeService.java
@@ -62,13 +62,14 @@ public class JobUrlConsumeService {
     public void consume(UrlMessage msg) throws Exception {
         final String url = msg.url();
         final JobSource source = (msg.source() != null) ? msg.source() : JobSource.JUSTJOIN;
+        final String externalId = msg.externalId();
 
         log.debug("[ingest] got msg source={} url={}", source, url);
 
         try {
-            dispatchBySource(url, source);
+            dispatchBySource(url, source, externalId);
         } catch (HttpStatusException e) {
-            handleHttpStatusException(e, url, source);
+            handleHttpStatusException(e, url, source, externalId);
         } catch (InterruptedIOException e) {
             handleInterruptedIo(url);
         } catch (IOException e) {
@@ -83,7 +84,7 @@ public class JobUrlConsumeService {
         }
     }
 
-    private void dispatchBySource(String url, JobSource source) throws Exception {
+    private void dispatchBySource(String url, JobSource source, String externalId) throws Exception {
         if (source == JobSource.JUSTJOIN) {
             String html = fetchJustjoinHtml(url);
             handleJustJoin(url, html, source);
@@ -91,7 +92,7 @@ public class JobUrlConsumeService {
         }
 
         if (source == JobSource.NOFLUFFJOBS) {
-            handleNofluff(url, source);
+            handleNofluff(url, source, externalId);
             return;
         }
 
@@ -114,12 +115,12 @@ public class JobUrlConsumeService {
         throw new AmqpRejectAndDontRequeueException("Unsupported source " + source);
     }
 
-    private void handleHttpStatusException(HttpStatusException e, String url, JobSource source) {
+    private void handleHttpStatusException(HttpStatusException e, String url, JobSource source, String externalId) {
         int sc = e.getStatusCode();
 
         if (sc == 404 || sc == 410) {
             logGone("[ingest] offer gone ({}): {} -> mark inactive", sc, url);
-            deactivateGoneOffer(source, url);
+            deactivateGoneOffer(source, url, externalId);
             return;
         }
 
@@ -148,7 +149,7 @@ public class JobUrlConsumeService {
     private void handleJustJoin(String url, String html, JobSource source) {
         if (justJoinParser.isExpiredPage(url, html)) {
             logGone("[ingest] JJ expired(200) page: {} -> mark inactive", url);
-            deactivateGoneOffer(source, url);
+            deactivateGoneOffer(source, url, null);
             return;
         }
         var parsed = justJoinParser.parse(url, html);
@@ -189,31 +190,27 @@ public class JobUrlConsumeService {
                 .outerHtml();
     }
 
-    private void handleNofluff(String url, JobSource source) throws IOException {
-        String externalId = lastPath(url);
+    private void handleNofluff(String url, JobSource source, String messageExternalId) throws IOException {
+        String externalId = normalizeNofluffExternalId(messageExternalId, url);
         String html = fetchNofluffHtml(url);
 
         if (nfjHtmlParser.isExpired(html)) {
             logGone("[ingest] NFJ expired by banner url={} -> mark inactive", url);
-            deactivateGoneOffer(source, url);
+            deactivateGoneOffer(source, url, externalId);
             return;
         }
 
         LocalDate validTo = nfjHtmlParser.extractValidTo(html);
-
-        boolean active = true;
-        if (validTo != null) {
-            active = !validTo.isBefore(LocalDate.now());
-        }
+        boolean active = validTo == null || !validTo.isBefore(LocalDate.now());
 
         if (!active) {
             logGone("[ingest] NFJ expired by HTML validTo={} url={} -> mark inactive", validTo, url);
-            deactivateGoneOffer(source, url);
+            deactivateGoneOffer(source, url, externalId);
             return;
         }
 
         String json = fetchNofluffJson(externalId);
-        var dto = nofluffParser.parseFromApiJson(externalId, json, url);
+        var dto = nofluffParser.parseFromApiJson(externalId, json, canonicalNofluffUrl(url, externalId));
 
         nofluffIngest.importSingle(dto);
         logOk("[ingest] NFJ upsert OK: {}", url);
@@ -234,6 +231,19 @@ public class JobUrlConsumeService {
                 .get()
                 .body()
                 .text();
+    }
+
+    private String fetchNofluffHtml(String url) throws IOException {
+        NFJ_FETCH_LIMITER.acquire();
+        return Jsoup.connect(url)
+                .userAgent(BROWSER_UA)
+                .referrer("https://nofluffjobs.com/")
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                .header("Accept-Language", "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7")
+                .followRedirects(true)
+                .timeout(15_000)
+                .get()
+                .outerHtml();
     }
 
     private void handleSolid(String url, JobSource source) throws IOException {
@@ -328,7 +338,7 @@ public class JobUrlConsumeService {
 
     private long delayFor429(JobSource source) {
         if (source == JobSource.NOFLUFFJOBS) {
-            return 60_000L;
+            return 300_000L;
         }
         if (source == JobSource.THEPROTOCOL) {
             return 30_000L;
@@ -379,24 +389,13 @@ public class JobUrlConsumeService {
         return url.substring(idx + marker.length());
     }
 
-    private String fetchNofluffHtml(String url) throws IOException {
-        NFJ_FETCH_LIMITER.acquire();
-        return Jsoup.connect(url)
-                .userAgent(BROWSER_UA)
-                .referrer("https://nofluffjobs.com/")
-                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-                .header("Accept-Language", "pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7")
-                .followRedirects(true)
-                .timeout(15_000)
-                .get()
-                .outerHtml();
-    }
-
-    private void deactivateGoneOffer(JobSource source, String url) {
+    private void deactivateGoneOffer(JobSource source, String url, String externalIdOverride) {
         JobSource safeSource = (source != null) ? source : JobSource.JUSTJOIN;
 
         String normUrl = normalizeUrl(url);
-        String externalId = lastPath(normUrl);
+        String externalId = (externalIdOverride != null && !externalIdOverride.isBlank())
+                ? externalIdOverride.trim()
+                : lastPath(normUrl);
 
         var opt = offers.findBySourceAndExternalId(safeSource, externalId);
         if (opt.isEmpty()) {
@@ -442,5 +441,19 @@ public class JobUrlConsumeService {
         String msg = (cause != null ? cause.getMessage() : e.getMessage());
         if (msg == null) return false;
         return msg.toLowerCase().contains("ux_job_offer_source_external");
+    }
+
+    private static String normalizeNofluffExternalId(String externalId, String url) {
+        if (externalId != null && !externalId.isBlank()) {
+            return externalId.trim();
+        }
+        return lastPath(url);
+    }
+
+    private static String canonicalNofluffUrl(String url, String externalId) {
+        if (externalId == null || externalId.isBlank()) {
+            return url;
+        }
+        return "https://nofluffjobs.com/pl/job/" + externalId;
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/UrlMessage.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/UrlMessage.java
@@ -4,5 +4,6 @@ import com.milosz.podsiadly.backend.job.domain.JobSource;
 
 public record UrlMessage(
         JobSource source,
-        String url
+        String url,
+        String externalId
 ) {}

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/IngestPublisher.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/IngestPublisher.java
@@ -18,7 +18,7 @@ public class IngestPublisher {
         rabbit.convertAndSend(
                 p.getExchange(),
                 p.getRouting().getUrls(),
-                new UrlMessage(source, url)
+                new UrlMessage(source, url, null)
         );
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/NofluffJobsIngestService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/NofluffJobsIngestService.java
@@ -1,29 +1,22 @@
 package com.milosz.podsiadly.backend.ingest.service;
 
 import com.milosz.podsiadly.backend.ingest.dto.NofluffJobDto;
-import com.milosz.podsiadly.backend.ingest.parser.NfjHtmlParser;
 import com.milosz.podsiadly.backend.job.domain.JobSource;
 import com.milosz.podsiadly.backend.job.domain.SalaryPeriod;
 import com.milosz.podsiadly.backend.job.service.ingest.ExternalJobOfferData;
 import com.milosz.podsiadly.backend.job.service.ingest.ExternalJobOfferIngestService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NofluffJobsIngestService {
 
     private final ExternalJobOfferIngestService ingestService;
-    private final RestTemplate restTemplate;
-    private final NfjHtmlParser htmlParser;
 
     @Transactional
     public void importSingle(NofluffJobDto dto) {
@@ -31,7 +24,7 @@ public class NofluffJobsIngestService {
         Instant published = (dto.publishedAt() != null) ? dto.publishedAt() : Instant.now();
         SalaryPeriod period = (dto.salaryPeriod() != null) ? dto.salaryPeriod() : SalaryPeriod.MONTH;
 
-        Boolean active = resolveActiveFromHtml(dto);
+        Boolean active = dto.active() != null ? dto.active() : true;
 
         ExternalJobOfferData data = new ExternalJobOfferData(
                 dto.title(),
@@ -55,26 +48,5 @@ public class NofluffJobsIngestService {
         );
 
         ingestService.ingest(JobSource.NOFLUFFJOBS, dto.externalId(), data);
-    }
-
-    private Boolean resolveActiveFromHtml(NofluffJobDto dto) {
-        if (dto.active() != null) return dto.active();
-
-        String url = dto.detailsUrl();
-        if (url == null || url.isBlank()) return true;
-
-        try {
-            String html = restTemplate.getForObject(url, String.class);
-            if (html == null || html.isBlank()) return true;
-
-            boolean expired = htmlParser.isExpired(html);
-            if (expired) {
-                log.info("[nfj] detected expired offer externalId={} url={}", dto.externalId(), url);
-            }
-            return !expired;
-        } catch (RestClientException ex) {
-            log.warn("[nfj] html fetch failed externalId={} url={} err={}", dto.externalId(), url, ex.toString());
-            return true;
-        }
     }
 }


### PR DESCRIPTION
 This update improves how NFJ offers are collected and processed when the platform runs large ingest cycles on AWS EC2.

  The main goal of these changes is to reduce unnecessary traffic, avoid processing the same offer multiple times, and make the system behave better when NFJ starts rate
  limiting requests. During bigger runs, the current flow can push a very large number of offer URLs through the queue, including multiple regional variants of the same
  posting. That creates avoidable load on the backend and increases the chance of 429 Too Many Requests responses.

  To address this, the crawler now passes a stable NFJ offer identifier instead of relying only on the visible job URL. This makes the flow much more reliable, because the
  backend no longer has to guess whether different URL variants refer to the same offer.

  The crawler is also cleaned up so duplicate NFJ offers are filtered earlier. That means fewer duplicate messages are sent to RabbitMQ and fewer duplicate jobs reach the
  backend. In practice, this should noticeably reduce unnecessary processing during large NFJ refreshes.

  On the backend side, the ingest path is simplified to avoid an extra HTML fetch that did not need to happen twice. The important HTML-based checks are still kept in
  place, so we do not lose offer expiration handling or other useful page-derived signals. The change is focused on removing redundant work, not weakening validation.

  Retry behavior was also adjusted to better handle NFJ throttling. When NFJ responds with 429, the system now waits longer before retrying instead of hammering the same
  source too quickly. This should make retries calmer and improve the chance that delayed messages succeed on later attempts.

  Logging around retry handling was also cleaned up so operational output is easier to read. Delayed retries should now look more intentional in logs instead of appearing
  like generic listener failures.

  Overall, this set of changes is aimed at making NFJ ingest more stable, less wasteful, and easier to operate when processing larger volumes of offers.

  Expected outcome:

  - fewer duplicate NFJ offers entering the backend
  - less unnecessary request volume
  - lower pressure on NFJ during large syncs
  - improved resilience when rate limiting happens
  - clearer logs during delayed retry flow
