### PR TITLE
CHB-46 Part 3: Ingest Routing, SolidJobs Finalization, and Auth Alignment

### DIFF
--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/IngestMessagingProperties.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/IngestMessagingProperties.java
@@ -17,17 +17,35 @@ public class IngestMessagingProperties {
 
     @Getter @Setter
     public static class Routing {
-        private String urls;
-        private String urlsRetry;
-        private String urlsDlq;
+        private String justjoinUrls;
+        private String justjoinUrlsRetry;
+        private String justjoinUrlsDlq;
+        private String nfjUrls;
+        private String nfjUrlsRetry;
+        private String nfjUrlsDlq;
+        private String solidUrls;
+        private String solidUrlsRetry;
+        private String solidUrlsDlq;
+        private String theProtocolUrls;
+        private String theProtocolUrlsRetry;
+        private String theProtocolUrlsDlq;
         private String externalOffers;
     }
 
     @Getter @Setter
     public static class QueueNames {
-        private String urls;
-        private String urlsRetry;
-        private String urlsDlq;
+        private String justjoinUrls;
+        private String justjoinUrlsRetry;
+        private String justjoinUrlsDlq;
+        private String nfjUrls;
+        private String nfjUrlsRetry;
+        private String nfjUrlsDlq;
+        private String solidUrls;
+        private String solidUrlsRetry;
+        private String solidUrlsDlq;
+        private String theProtocolUrls;
+        private String theProtocolUrlsRetry;
+        private String theProtocolUrlsDlq;
         private String externalOffers;
     }
 }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/RabbitConfig.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/RabbitConfig.java
@@ -29,18 +29,63 @@ public class RabbitConfig {
     }
 
     @Bean
-    public Queue urlsQueue(IngestMessagingProperties props) {
-        return QueueBuilder.durable(props.getQueue().getUrls()).build();
+    public Queue justjoinUrlsQueue(IngestMessagingProperties props) {
+        return QueueBuilder.durable(props.getQueue().getJustjoinUrls()).build();
     }
 
     @Bean
-    public Binding urlsBinding(Queue urlsQueue,
-                               DirectExchange jobsExchange,
-                               IngestMessagingProperties props) {
+    public Binding justjoinUrlsBinding(Queue justjoinUrlsQueue,
+                                       DirectExchange jobsExchange,
+                                       IngestMessagingProperties props) {
         return BindingBuilder
-                .bind(urlsQueue)
+                .bind(justjoinUrlsQueue)
                 .to(jobsExchange)
-                .with(props.getRouting().getUrls());
+                .with(props.getRouting().getJustjoinUrls());
+    }
+
+    @Bean
+    public Queue nfjUrlsQueue(IngestMessagingProperties props) {
+        return QueueBuilder.durable(props.getQueue().getNfjUrls()).build();
+    }
+
+    @Bean
+    public Binding nfjUrlsBinding(Queue nfjUrlsQueue,
+                                  DirectExchange jobsExchange,
+                                  IngestMessagingProperties props) {
+        return BindingBuilder
+                .bind(nfjUrlsQueue)
+                .to(jobsExchange)
+                .with(props.getRouting().getNfjUrls());
+    }
+
+    @Bean
+    public Queue solidUrlsQueue(IngestMessagingProperties props) {
+        return QueueBuilder.durable(props.getQueue().getSolidUrls()).build();
+    }
+
+    @Bean
+    public Binding solidUrlsBinding(Queue solidUrlsQueue,
+                                    DirectExchange jobsExchange,
+                                    IngestMessagingProperties props) {
+        return BindingBuilder
+                .bind(solidUrlsQueue)
+                .to(jobsExchange)
+                .with(props.getRouting().getSolidUrls());
+    }
+
+    @Bean
+    public Queue theProtocolUrlsQueue(IngestMessagingProperties props) {
+        return QueueBuilder.durable(props.getQueue().getTheProtocolUrls()).build();
+    }
+
+    @Bean
+    public Binding theProtocolUrlsBinding(Queue theProtocolUrlsQueue,
+                                          DirectExchange jobsExchange,
+                                          IngestMessagingProperties props) {
+        return BindingBuilder
+                .bind(theProtocolUrlsQueue)
+                .to(jobsExchange)
+                .with(props.getRouting().getTheProtocolUrls());
     }
 
     @Bean

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/SchedulingConfig.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/SchedulingConfig.java
@@ -1,0 +1,19 @@
+package com.milosz.podsiadly.careerhub.agentcrawler.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulingConfig {
+
+    @Bean
+    TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("agent-scheduler-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/NfjJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/NfjJobPublisher.java
@@ -2,9 +2,11 @@ package com.milosz.podsiadly.careerhub.agentcrawler.mq;
 
 import com.milosz.podsiadly.careerhub.agentcrawler.config.IngestMessagingProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NfjJobPublisher {
@@ -24,10 +26,14 @@ public class NfjJobPublisher {
 
     public void publishUrl(String url, String source, String externalId) {
         UrlMessage msg = new UrlMessage(url, source, externalId);
+        String routingKey = props.getRouting().getNfjUrls();
+
+        log.debug("[mq] nfj publish source={} externalId={} routingKey={} url={}",
+                source, externalId, routingKey, url);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),
-                props.getRouting().getUrls(),
+                routingKey,
                 msg
         );
     }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/SolidJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/SolidJobPublisher.java
@@ -2,9 +2,11 @@ package com.milosz.podsiadly.careerhub.agentcrawler.mq;
 
 import com.milosz.podsiadly.careerhub.agentcrawler.config.IngestMessagingProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SolidJobPublisher {
@@ -16,10 +18,13 @@ public class SolidJobPublisher {
 
     public void publishUrl(String url) {
         UrlMessage msg = new UrlMessage(url, SOURCE_SOLID, null);
+        String routingKey = props.getRouting().getSolidUrls();
+
+        log.debug("[mq] solid publish source={} routingKey={} url={}", SOURCE_SOLID, routingKey, url);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),
-                props.getRouting().getUrls(),
+                routingKey,
                 msg
         );
     }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/TheProtocolJobPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/mq/TheProtocolJobPublisher.java
@@ -2,9 +2,11 @@ package com.milosz.podsiadly.careerhub.agentcrawler.mq;
 
 import com.milosz.podsiadly.careerhub.agentcrawler.config.IngestMessagingProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TheProtocolJobPublisher {
@@ -16,10 +18,13 @@ public class TheProtocolJobPublisher {
 
     public void publishUrl(String url) {
         UrlMessage msg = new UrlMessage(url, SOURCE_THEPROTOCOL, null);
+        String routingKey = props.getRouting().getTheProtocolUrls();
+
+        log.debug("[mq] theprotocol publish source={} routingKey={} url={}", SOURCE_THEPROTOCOL, routingKey, url);
 
         rabbitTemplate.convertAndSend(
                 props.getExchange(),
-                props.getRouting().getUrls(),
+                routingKey,
                 msg
         );
     }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/SolidCrawlerScheduler.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/SolidCrawlerScheduler.java
@@ -1,5 +1,6 @@
 package com.milosz.podsiadly.careerhub.agentcrawler.solid;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.milosz.podsiadly.careerhub.agentcrawler.mq.SolidJobPublisher;
 import com.milosz.podsiadly.careerhub.agentcrawler.solid.api.SolidApiClient;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,8 @@ import java.util.Set;
 @Component
 @RequiredArgsConstructor
 public class SolidCrawlerScheduler {
+
+    private static final RateLimiter PUBLISH_LIMITER = RateLimiter.create(2.0d);
 
     private final SolidApiClient solidApiClient;
     private final SolidJobPublisher publisher;
@@ -37,6 +40,7 @@ public class SolidCrawlerScheduler {
 
             int count = 0;
             for (String url : urls) {
+                PUBLISH_LIMITER.acquire();
                 publisher.publishUrl(url);
                 count++;
             }

--- a/agent-crawler/src/main/resources/application-aws.yml
+++ b/agent-crawler/src/main/resources/application-aws.yml
@@ -25,21 +25,21 @@ management:
 agent:
   nfj:
     start-url: "https://nofluffjobs.com/pl/it?device=mobile"
-    initial-delay-ms: 1200000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   solid:
     sitemap-url: "https://solid.jobs/sitemap.xml"
-    initial-delay-ms: 5000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   theprotocol:
     sitemap-url: "https://static.theprotocol.it/sitemaps/CurrentOffers/SiteMapJobOffers1.xml"
-    initial-delay-ms: 2400000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   pracuj:
-    initial-delay-ms: 3000000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   playwright:
@@ -49,14 +49,32 @@ jobs:
   ingest:
     exchange: ingest.jobs
     routing:
-      urls: job-url
-      urlsRetry: job-url.retry
-      urlsDlq: job-url.dlq
+      justjoinUrls: job-url.justjoin
+      justjoinUrlsRetry: job-url.justjoin.retry
+      justjoinUrlsDlq: job-url.justjoin.dlq
+      nfjUrls: job-url.nfj
+      nfjUrlsRetry: job-url.nfj.retry
+      nfjUrlsDlq: job-url.nfj.dlq
+      solidUrls: job-url.solid
+      solidUrlsRetry: job-url.solid.retry
+      solidUrlsDlq: job-url.solid.dlq
+      theProtocolUrls: job-url.theprotocol
+      theProtocolUrlsRetry: job-url.theprotocol.retry
+      theProtocolUrlsDlq: job-url.theprotocol.dlq
       externalOffers: external-offer
     queue:
-      urls: ingest.jobs.url
-      urlsRetry: ingest.jobs.url.retry
-      urlsDlq: ingest.jobs.url.dlq
+      justjoinUrls: ingest.jobs.url.justjoin
+      justjoinUrlsRetry: ingest.jobs.url.justjoin.retry
+      justjoinUrlsDlq: ingest.jobs.url.justjoin.dlq
+      nfjUrls: ingest.jobs.url.nfj
+      nfjUrlsRetry: ingest.jobs.url.nfj.retry
+      nfjUrlsDlq: ingest.jobs.url.nfj.dlq
+      solidUrls: ingest.jobs.url.solid
+      solidUrlsRetry: ingest.jobs.url.solid.retry
+      solidUrlsDlq: ingest.jobs.url.solid.dlq
+      theProtocolUrls: ingest.jobs.url.theprotocol
+      theProtocolUrlsRetry: ingest.jobs.url.theprotocol.retry
+      theProtocolUrlsDlq: ingest.jobs.url.theprotocol.dlq
       externalOffers: ingest.jobs.external-offers
 
 eureka:

--- a/agent-crawler/src/main/resources/application.yml
+++ b/agent-crawler/src/main/resources/application.yml
@@ -26,21 +26,21 @@ management:
 agent:
   nfj:
     start-url: "https://nofluffjobs.com/pl/it?device=mobile"
-    initial-delay-ms: 1200000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   solid:
     sitemap-url: "https://solid.jobs/sitemap.xml"
-    initial-delay-ms: 5000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   theprotocol:
     sitemap-url: "https://static.theprotocol.it/sitemaps/CurrentOffers/SiteMapJobOffers1.xml"
-    initial-delay-ms: 2400000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   pracuj:
-    initial-delay-ms: 3000000
+    initial-delay-ms: 60000
     interval-ms: 108000000
 
   playwright:
@@ -50,14 +50,32 @@ jobs:
   ingest:
     exchange: ingest.jobs
     routing:
-      urls: job-url
-      urlsRetry: job-url.retry
-      urlsDlq: job-url.dlq
+      justjoinUrls: job-url.justjoin
+      justjoinUrlsRetry: job-url.justjoin.retry
+      justjoinUrlsDlq: job-url.justjoin.dlq
+      nfjUrls: job-url.nfj
+      nfjUrlsRetry: job-url.nfj.retry
+      nfjUrlsDlq: job-url.nfj.dlq
+      solidUrls: job-url.solid
+      solidUrlsRetry: job-url.solid.retry
+      solidUrlsDlq: job-url.solid.dlq
+      theProtocolUrls: job-url.theprotocol
+      theProtocolUrlsRetry: job-url.theprotocol.retry
+      theProtocolUrlsDlq: job-url.theprotocol.dlq
       externalOffers: external-offer
     queue:
-      urls: ingest.jobs.url
-      urlsRetry: ingest.jobs.url.retry
-      urlsDlq: ingest.jobs.url.dlq
+      justjoinUrls: ingest.jobs.url.justjoin
+      justjoinUrlsRetry: ingest.jobs.url.justjoin.retry
+      justjoinUrlsDlq: ingest.jobs.url.justjoin.dlq
+      nfjUrls: ingest.jobs.url.nfj
+      nfjUrlsRetry: ingest.jobs.url.nfj.retry
+      nfjUrlsDlq: ingest.jobs.url.nfj.dlq
+      solidUrls: ingest.jobs.url.solid
+      solidUrlsRetry: ingest.jobs.url.solid.retry
+      solidUrlsDlq: ingest.jobs.url.solid.dlq
+      theProtocolUrls: ingest.jobs.url.theprotocol
+      theProtocolUrlsRetry: ingest.jobs.url.theprotocol.retry
+      theProtocolUrlsDlq: ingest.jobs.url.theprotocol.dlq
       externalOffers: ingest.jobs.external-offers
 
 eureka:

--- a/backend/src/main/java/com/milosz/podsiadly/backend/infrastructure/loginandregister/controller/TokenController.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/infrastructure/loginandregister/controller/TokenController.java
@@ -148,6 +148,9 @@ public class TokenController {
 
     @GetMapping("/me")
     public MeDto me(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized");
+        }
         var p = profiles.findByUserId(user.getId()).orElse(null);
         return toMeDto(
                 user,

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/IngestMessagingProperties.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/IngestMessagingProperties.java
@@ -17,17 +17,35 @@ public class IngestMessagingProperties {
 
     @Getter @Setter
     public static class Routing {
-        private String urls;
-        private String urlsRetry;
-        private String urlsDlq;
+        private String justjoinUrls;
+        private String justjoinUrlsRetry;
+        private String justjoinUrlsDlq;
+        private String nfjUrls;
+        private String nfjUrlsRetry;
+        private String nfjUrlsDlq;
+        private String solidUrls;
+        private String solidUrlsRetry;
+        private String solidUrlsDlq;
+        private String theProtocolUrls;
+        private String theProtocolUrlsRetry;
+        private String theProtocolUrlsDlq;
         private String externalOffers;
     }
 
     @Getter @Setter
     public static class QueueNames {
-        private String urls;
-        private String urlsRetry;
-        private String urlsDlq;
+        private String justjoinUrls;
+        private String justjoinUrlsRetry;
+        private String justjoinUrlsDlq;
+        private String nfjUrls;
+        private String nfjUrlsRetry;
+        private String nfjUrlsDlq;
+        private String solidUrls;
+        private String solidUrlsRetry;
+        private String solidUrlsDlq;
+        private String theProtocolUrls;
+        private String theProtocolUrlsRetry;
+        private String theProtocolUrlsDlq;
         private String externalOffers;
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitConfig.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitConfig.java
@@ -27,38 +27,143 @@ public class RabbitConfig {
     }
 
     @Bean
-    Queue urlsQueue(IngestMessagingProperties p) {
-        return QueueBuilder.durable(p.getQueue().getUrls()).build();
+    Queue justjoinUrlsQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getJustjoinUrls()).build();
     }
 
     @Bean
-    Binding urlsBinding(Queue urlsQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
-        return BindingBuilder.bind(urlsQueue).to(jobsExchange).with(p.getRouting().getUrls());
+    Binding justjoinUrlsBinding(Queue justjoinUrlsQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(justjoinUrlsQueue).to(jobsExchange).with(p.getRouting().getJustjoinUrls());
     }
 
     @Bean
-    Queue urlsRetryQueue(IngestMessagingProperties p) {
-        return QueueBuilder.durable(p.getQueue().getUrlsRetry())
+    Queue justjoinUrlsRetryQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getJustjoinUrlsRetry())
                 .withArguments(Map.of(
                         "x-dead-letter-exchange", p.getExchange(),
-                        "x-dead-letter-routing-key", p.getRouting().getUrls()
+                        "x-dead-letter-routing-key", p.getRouting().getJustjoinUrls()
                 ))
                 .build();
     }
 
     @Bean
-    Binding urlsRetryBinding(Queue urlsRetryQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
-        return BindingBuilder.bind(urlsRetryQueue).to(jobsExchange).with(p.getRouting().getUrlsRetry());
+    Binding justjoinUrlsRetryBinding(Queue justjoinUrlsRetryQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(justjoinUrlsRetryQueue).to(jobsExchange).with(p.getRouting().getJustjoinUrlsRetry());
     }
 
     @Bean
-    Queue urlsDlqQueue(IngestMessagingProperties p) {
-        return QueueBuilder.durable(p.getQueue().getUrlsDlq()).build();
+    Queue justjoinUrlsDlqQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getJustjoinUrlsDlq()).build();
     }
 
     @Bean
-    Binding urlsDlqBinding(Queue urlsDlqQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
-        return BindingBuilder.bind(urlsDlqQueue).to(jobsExchange).with(p.getRouting().getUrlsDlq());
+    Binding justjoinUrlsDlqBinding(Queue justjoinUrlsDlqQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(justjoinUrlsDlqQueue).to(jobsExchange).with(p.getRouting().getJustjoinUrlsDlq());
+    }
+
+    @Bean
+    Queue nfjUrlsQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getNfjUrls()).build();
+    }
+
+    @Bean
+    Binding nfjUrlsBinding(Queue nfjUrlsQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(nfjUrlsQueue).to(jobsExchange).with(p.getRouting().getNfjUrls());
+    }
+
+    @Bean
+    Queue nfjUrlsRetryQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getNfjUrlsRetry())
+                .withArguments(Map.of(
+                        "x-dead-letter-exchange", p.getExchange(),
+                        "x-dead-letter-routing-key", p.getRouting().getNfjUrls()
+                ))
+                .build();
+    }
+
+    @Bean
+    Binding nfjUrlsRetryBinding(Queue nfjUrlsRetryQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(nfjUrlsRetryQueue).to(jobsExchange).with(p.getRouting().getNfjUrlsRetry());
+    }
+
+    @Bean
+    Queue nfjUrlsDlqQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getNfjUrlsDlq()).build();
+    }
+
+    @Bean
+    Binding nfjUrlsDlqBinding(Queue nfjUrlsDlqQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(nfjUrlsDlqQueue).to(jobsExchange).with(p.getRouting().getNfjUrlsDlq());
+    }
+
+    @Bean
+    Queue solidUrlsQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getSolidUrls()).build();
+    }
+
+    @Bean
+    Binding solidUrlsBinding(Queue solidUrlsQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(solidUrlsQueue).to(jobsExchange).with(p.getRouting().getSolidUrls());
+    }
+
+    @Bean
+    Queue solidUrlsRetryQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getSolidUrlsRetry())
+                .withArguments(Map.of(
+                        "x-dead-letter-exchange", p.getExchange(),
+                        "x-dead-letter-routing-key", p.getRouting().getSolidUrls()
+                ))
+                .build();
+    }
+
+    @Bean
+    Binding solidUrlsRetryBinding(Queue solidUrlsRetryQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(solidUrlsRetryQueue).to(jobsExchange).with(p.getRouting().getSolidUrlsRetry());
+    }
+
+    @Bean
+    Queue solidUrlsDlqQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getSolidUrlsDlq()).build();
+    }
+
+    @Bean
+    Binding solidUrlsDlqBinding(Queue solidUrlsDlqQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(solidUrlsDlqQueue).to(jobsExchange).with(p.getRouting().getSolidUrlsDlq());
+    }
+
+    @Bean
+    Queue theProtocolUrlsQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getTheProtocolUrls()).build();
+    }
+
+    @Bean
+    Binding theProtocolUrlsBinding(Queue theProtocolUrlsQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(theProtocolUrlsQueue).to(jobsExchange).with(p.getRouting().getTheProtocolUrls());
+    }
+
+    @Bean
+    Queue theProtocolUrlsRetryQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getTheProtocolUrlsRetry())
+                .withArguments(Map.of(
+                        "x-dead-letter-exchange", p.getExchange(),
+                        "x-dead-letter-routing-key", p.getRouting().getTheProtocolUrls()
+                ))
+                .build();
+    }
+
+    @Bean
+    Binding theProtocolUrlsRetryBinding(Queue theProtocolUrlsRetryQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(theProtocolUrlsRetryQueue).to(jobsExchange).with(p.getRouting().getTheProtocolUrlsRetry());
+    }
+
+    @Bean
+    Queue theProtocolUrlsDlqQueue(IngestMessagingProperties p) {
+        return QueueBuilder.durable(p.getQueue().getTheProtocolUrlsDlq()).build();
+    }
+
+    @Bean
+    Binding theProtocolUrlsDlqBinding(Queue theProtocolUrlsDlqQueue, DirectExchange jobsExchange, IngestMessagingProperties p) {
+        return BindingBuilder.bind(theProtocolUrlsDlqQueue).to(jobsExchange).with(p.getRouting().getTheProtocolUrlsDlq());
     }
 
     @Bean

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitListenerDelayedStarter.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitListenerDelayedStarter.java
@@ -1,5 +1,6 @@
 package com.milosz.podsiadly.backend.ingest.config;
 
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
 import org.springframework.beans.factory.ObjectProvider;
@@ -12,6 +13,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 class RabbitListenerDelayedStarter {
     private final TaskScheduler taskScheduler;
@@ -22,9 +24,19 @@ class RabbitListenerDelayedStarter {
         taskScheduler.schedule(() -> {
             var reg = registryProvider.getIfAvailable();
             if (reg == null) return;
-            var c = reg.getListenerContainer("jobUrlConsumer");
-            if (c != null && !c.isRunning()) c.start();
+            startIfNeeded(reg, "justjoinJobUrlConsumer");
+            startIfNeeded(reg, "nfjJobUrlConsumer");
+            startIfNeeded(reg, "solidJobUrlConsumer");
+            startIfNeeded(reg, "theProtocolJobUrlConsumer");
         }, Instant.now().plus(Duration.ofMinutes(3)));
+    }
+
+    private static void startIfNeeded(RabbitListenerEndpointRegistry registry, String listenerId) {
+        var container = registry.getListenerContainer(listenerId);
+        if (container != null && !container.isRunning()) {
+            container.start();
+            log.info("[amqp] started listener={}", listenerId);
+        }
     }
 }
 

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumeService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumeService.java
@@ -37,6 +37,7 @@ public class JobUrlConsumeService {
 
     private static final RateLimiter NFJ_FETCH_LIMITER = RateLimiter.create(0.5d);
     private static final RateLimiter TP_FETCH_LIMITER  = RateLimiter.create(1.0d);
+    private static final RateLimiter SOLID_FETCH_LIMITER = RateLimiter.create(2.0d);
 
     private static final Pattern TP_OFFER_ID = Pattern.compile(
             "(?:,oferta,|%2Coferta%2C)([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
@@ -252,6 +253,7 @@ public class JobUrlConsumeService {
         String apiUrl = "https://solid.jobs/api/offers/" + apiPath;
 
         log.debug("[ingest] SOLID fetch apiUrl={} (externalId={})", apiUrl, externalId);
+        SOLID_FETCH_LIMITER.acquire();
 
         String json = Jsoup.connect(apiUrl)
                 .ignoreContentType(true)

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumer.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlConsumer.java
@@ -15,15 +15,53 @@ public class JobUrlConsumer {
     private final JobUrlRetryPublisher retryPublisher;
 
     @RabbitListener(
-            id = "jobUrlConsumer",
-            queues = "#{ingestMessagingProperties.queue.urls}",
+            id = "justjoinJobUrlConsumer",
+            queues = "#{ingestMessagingProperties.queue.justjoinUrls}",
             containerFactory = "rabbitListenerContainerFactory",
             autoStartup = "false"
     )
-    public void onMessage(UrlMessage msg, Message message) throws Exception {
+    public void onJustjoinMessage(UrlMessage msg, Message message) throws Exception {
+        handle("justjoin-url", msg, message);
+    }
+
+    @RabbitListener(
+            id = "nfjJobUrlConsumer",
+            queues = "#{ingestMessagingProperties.queue.nfjUrls}",
+            containerFactory = "rabbitListenerContainerFactory",
+            autoStartup = "false"
+    )
+    public void onNfjMessage(UrlMessage msg, Message message) throws Exception {
+        handle("nfj-url", msg, message);
+    }
+
+    @RabbitListener(
+            id = "solidJobUrlConsumer",
+            queues = "#{ingestMessagingProperties.queue.solidUrls}",
+            containerFactory = "rabbitListenerContainerFactory",
+            autoStartup = "false"
+    )
+    public void onSolidMessage(UrlMessage msg, Message message) throws Exception {
+        handle("solid-url", msg, message);
+    }
+
+    @RabbitListener(
+            id = "theProtocolJobUrlConsumer",
+            queues = "#{ingestMessagingProperties.queue.theProtocolUrls}",
+            containerFactory = "rabbitListenerContainerFactory",
+            autoStartup = "false"
+    )
+    public void onTheProtocolMessage(UrlMessage msg, Message message) throws Exception {
+        handle("theprotocol-url", msg, message);
+    }
+
+    private void handle(String listenerName, UrlMessage msg, Message message) throws Exception {
+        log.debug("[ingest] listener={} source={} url={} thread={}",
+                listenerName, msg.source(), msg.url(), Thread.currentThread().getName());
         try {
             consumeService.consume(msg);
         } catch (DelayedRetryException e) {
+            log.debug("[ingest] listener={} delayed-retry source={} url={} delayMs={}",
+                    listenerName, msg.source(), msg.url(), e.getDelayMs());
             retryPublisher.publishDelayedRetry(msg, e.getDelayMs(), currentRetryCount(message));
             throw e;
         }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlRetryPublisher.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/JobUrlRetryPublisher.java
@@ -1,6 +1,7 @@
 package com.milosz.podsiadly.backend.ingest.mq;
 
 import com.milosz.podsiadly.backend.ingest.config.IngestMessagingProperties;
+import com.milosz.podsiadly.backend.job.domain.JobSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.MessagePostProcessor;
@@ -27,7 +28,7 @@ public class JobUrlRetryPublisher {
 
             rabbitTemplate.convertAndSend(
                     properties.getExchange(),
-                    properties.getRouting().getUrlsDlq(),
+                    dlqRoutingFor(msg),
                     msg,
                     message -> {
                         message.getMessageProperties().setHeader(RETRY_COUNT_HEADER, nextRetryCount);
@@ -48,9 +49,33 @@ public class JobUrlRetryPublisher {
 
         rabbitTemplate.convertAndSend(
                 properties.getExchange(),
-                properties.getRouting().getUrlsRetry(),
+                retryRoutingFor(msg),
                 msg,
                 mpp
         );
+    }
+
+    private String retryRoutingFor(UrlMessage msg) {
+        if (msg == null || msg.source() == null) {
+            return properties.getRouting().getJustjoinUrlsRetry();
+        }
+        return switch (msg.source()) {
+            case NOFLUFFJOBS -> properties.getRouting().getNfjUrlsRetry();
+            case SOLIDJOBS -> properties.getRouting().getSolidUrlsRetry();
+            case THEPROTOCOL -> properties.getRouting().getTheProtocolUrlsRetry();
+            default -> properties.getRouting().getJustjoinUrlsRetry();
+        };
+    }
+
+    private String dlqRoutingFor(UrlMessage msg) {
+        if (msg == null || msg.source() == null) {
+            return properties.getRouting().getJustjoinUrlsDlq();
+        }
+        return switch (msg.source()) {
+            case NOFLUFFJOBS -> properties.getRouting().getNfjUrlsDlq();
+            case SOLIDJOBS -> properties.getRouting().getSolidUrlsDlq();
+            case THEPROTOCOL -> properties.getRouting().getTheProtocolUrlsDlq();
+            default -> properties.getRouting().getJustjoinUrlsDlq();
+        };
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/IngestPublisher.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/service/IngestPublisher.java
@@ -4,9 +4,11 @@ import com.milosz.podsiadly.backend.ingest.config.IngestMessagingProperties;
 import com.milosz.podsiadly.backend.ingest.mq.UrlMessage;
 import com.milosz.podsiadly.backend.job.domain.JobSource;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class IngestPublisher {
@@ -15,10 +17,26 @@ public class IngestPublisher {
     private final IngestMessagingProperties p;
 
     public void publishUrl(String url, JobSource source) {
+        String routingKey = routingKeyFor(source);
+
+        log.debug("[ingest] publish source={} routingKey={} url={}", source, routingKey, url);
+
         rabbit.convertAndSend(
                 p.getExchange(),
-                p.getRouting().getUrls(),
+                routingKey,
                 new UrlMessage(source, url, null)
         );
+    }
+
+    private String routingKeyFor(JobSource source) {
+        if (source == null) {
+            return p.getRouting().getJustjoinUrls();
+        }
+        return switch (source) {
+            case NOFLUFFJOBS -> p.getRouting().getNfjUrls();
+            case SOLIDJOBS -> p.getRouting().getSolidUrls();
+            case THEPROTOCOL -> p.getRouting().getTheProtocolUrls();
+            default -> p.getRouting().getJustjoinUrls();
+        };
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/security/SecurityConfig.java
@@ -42,7 +42,17 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .authorizeHttpRequests(reg -> reg
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+                        .requestMatchers(
+                                "/api/auth/forgot-password",
+                                "/api/auth/reset-password",
+                                "/api/auth/register",
+                                "/api/auth/verify-email",
+                                "/api/auth/login",
+                                "/api/auth/refresh",
+                                "/api/auth/logout",
+                                "/api/auth/resend-verification"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/public/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/salary/calculate").permitAll()

--- a/backend/src/main/java/com/milosz/podsiadly/backend/security/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/security/jwt/JwtFilter.java
@@ -99,6 +99,19 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest req) {
         String p = req.getRequestURI();
-        return p != null && p.startsWith("/api/auth/");
+        if (p == null) {
+            return false;
+        }
+        return switch (p) {
+            case "/api/auth/forgot-password",
+                 "/api/auth/reset-password",
+                 "/api/auth/register",
+                 "/api/auth/verify-email",
+                 "/api/auth/login",
+                 "/api/auth/refresh",
+                 "/api/auth/logout",
+                 "/api/auth/resend-verification" -> true;
+            default -> false;
+        };
     }
 }

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -57,6 +57,8 @@ management:
         include: "health,info"
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: "when_authorized"
 
 auth:
@@ -76,14 +78,32 @@ jobs:
   ingest:
     exchange: ingest.jobs
     routing:
-      urls: job-url
-      urlsRetry: job-url.retry
-      urlsDlq: job-url.dlq
+      justjoinUrls: job-url.justjoin
+      justjoinUrlsRetry: job-url.justjoin.retry
+      justjoinUrlsDlq: job-url.justjoin.dlq
+      nfjUrls: job-url.nfj
+      nfjUrlsRetry: job-url.nfj.retry
+      nfjUrlsDlq: job-url.nfj.dlq
+      solidUrls: job-url.solid
+      solidUrlsRetry: job-url.solid.retry
+      solidUrlsDlq: job-url.solid.dlq
+      theProtocolUrls: job-url.theprotocol
+      theProtocolUrlsRetry: job-url.theprotocol.retry
+      theProtocolUrlsDlq: job-url.theprotocol.dlq
       externalOffers: external-offer
     queue:
-      urls: ingest.jobs.url
-      urlsRetry: ingest.jobs.url.retry
-      urlsDlq: ingest.jobs.url.dlq
+      justjoinUrls: ingest.jobs.url.justjoin
+      justjoinUrlsRetry: ingest.jobs.url.justjoin.retry
+      justjoinUrlsDlq: ingest.jobs.url.justjoin.dlq
+      nfjUrls: ingest.jobs.url.nfj
+      nfjUrlsRetry: ingest.jobs.url.nfj.retry
+      nfjUrlsDlq: ingest.jobs.url.nfj.dlq
+      solidUrls: ingest.jobs.url.solid
+      solidUrlsRetry: ingest.jobs.url.solid.retry
+      solidUrlsDlq: ingest.jobs.url.solid.dlq
+      theProtocolUrls: ingest.jobs.url.theprotocol
+      theProtocolUrlsRetry: ingest.jobs.url.theprotocol.retry
+      theProtocolUrlsDlq: ingest.jobs.url.theprotocol.dlq
       externalOffers: ingest.jobs.external-offers
     source-default: JUSTJOIN
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -57,6 +57,8 @@ management:
         include: "health,info"
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: "when_authorized"
 
 auth:
@@ -76,14 +78,32 @@ jobs:
   ingest:
     exchange: ingest.jobs
     routing:
-      urls: job-url
-      urlsRetry: job-url.retry
-      urlsDlq: job-url.dlq
+      justjoinUrls: job-url.justjoin
+      justjoinUrlsRetry: job-url.justjoin.retry
+      justjoinUrlsDlq: job-url.justjoin.dlq
+      nfjUrls: job-url.nfj
+      nfjUrlsRetry: job-url.nfj.retry
+      nfjUrlsDlq: job-url.nfj.dlq
+      solidUrls: job-url.solid
+      solidUrlsRetry: job-url.solid.retry
+      solidUrlsDlq: job-url.solid.dlq
+      theProtocolUrls: job-url.theprotocol
+      theProtocolUrlsRetry: job-url.theprotocol.retry
+      theProtocolUrlsDlq: job-url.theprotocol.dlq
       externalOffers: external-offer
     queue:
-      urls: ingest.jobs.url
-      urlsRetry: ingest.jobs.url.retry
-      urlsDlq: ingest.jobs.url.dlq
+      justjoinUrls: ingest.jobs.url.justjoin
+      justjoinUrlsRetry: ingest.jobs.url.justjoin.retry
+      justjoinUrlsDlq: ingest.jobs.url.justjoin.dlq
+      nfjUrls: ingest.jobs.url.nfj
+      nfjUrlsRetry: ingest.jobs.url.nfj.retry
+      nfjUrlsDlq: ingest.jobs.url.nfj.dlq
+      solidUrls: ingest.jobs.url.solid
+      solidUrlsRetry: ingest.jobs.url.solid.retry
+      solidUrlsDlq: ingest.jobs.url.solid.dlq
+      theProtocolUrls: ingest.jobs.url.theprotocol
+      theProtocolUrlsRetry: ingest.jobs.url.theprotocol.retry
+      theProtocolUrlsDlq: ingest.jobs.url.theprotocol.dlq
       externalOffers: ingest.jobs.external-offers
     source-default: JUSTJOIN
 

--- a/frontend/src/shared/api.ts
+++ b/frontend/src/shared/api.ts
@@ -13,6 +13,16 @@ type ResetPasswordPayload = { token: string; newPassword: string };
 
 const ACCESS_KEY = 'accessToken';
 const USER_KEY = 'ch.user';
+const PUBLIC_AUTH_PATHS = new Set([
+    '/auth/forgot-password',
+    '/auth/reset-password',
+    '/auth/register',
+    '/auth/verify-email',
+    '/auth/login',
+    '/auth/refresh',
+    '/auth/logout',
+    '/auth/resend-verification',
+]);
 
 function readSession<T>(key: string): T | null {
     const raw = sessionStorage.getItem(key);
@@ -77,10 +87,11 @@ function userFromToken(token: string | null): AuthUser {
 }
 
 const isAuthPath = (p: string) => p.startsWith('/auth/');
+const isPublicAuthPath = (p: string) => PUBLIC_AUTH_PATHS.has(p);
 
 function isPublicRequest(path: string, method: string): boolean {
     const m = method.toUpperCase();
-    if (isAuthPath(path)) return true;
+    if (isPublicAuthPath(path)) return true;
     if (m === 'POST' && path === '/salary/calculate') return true;
     if (m !== 'GET') return false;
     if (path.startsWith('/public/')) return true;
@@ -154,7 +165,7 @@ async function request<T = any>(path: string, opts: RequestInit = {}, retry = tr
     if (sentAuth && accessToken) headers.Authorization = `Bearer ${accessToken}`;
 
     const res = await rawFetch(path, opts, headers);
-    if (res.status === 401 && retry && !isAuthPath(path) && sentAuth) {
+    if (res.status === 401 && retry && !isPublicAuthPath(path) && sentAuth) {
         try {
             await doRefresh();
             return request<T>(path, opts, false);

--- a/gateway/src/main/java/com/milosz/podsiadly/gateway/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/milosz/podsiadly/gateway/config/SecurityConfig.java
@@ -24,7 +24,17 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(eh -> eh.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+                        .requestMatchers(
+                                "/api/auth/forgot-password",
+                                "/api/auth/reset-password",
+                                "/api/auth/register",
+                                "/api/auth/verify-email",
+                                "/api/auth/login",
+                                "/api/auth/refresh",
+                                "/api/auth/logout",
+                                "/api/auth/resend-verification"
+                        ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/public/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/salary/calculate").permitAll()

--- a/gateway/src/main/resources/application-aws.yml
+++ b/gateway/src/main/resources/application-aws.yml
@@ -32,6 +32,8 @@ management:
         include: ${MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE:health,info}
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: "when_authorized"
 
 auth:

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -32,6 +32,8 @@ management:
         include: "health,info"
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: "when_authorized"
 
 auth:

--- a/gateway/src/test/java/com/milosz/podsiadly/gateway/integration/SecurityConfigTests.java
+++ b/gateway/src/test/java/com/milosz/podsiadly/gateway/integration/SecurityConfigTests.java
@@ -61,7 +61,8 @@ class SecurityConfigTests extends GatewayApplicationTests {
     static Stream<Case> cases() {
         return Stream.of(
                 new Case("auth/** permitAll", HttpMethod.POST, "/api/auth/login", Auth.NONE, HttpStatus.OK, true),
-                new Case("auth/** permitAll (GET)", HttpMethod.GET, "/api/auth/me", Auth.NONE, HttpStatus.OK, true),
+                new Case("auth me requires auth", HttpMethod.GET, "/api/auth/me", Auth.NONE, HttpStatus.UNAUTHORIZED, false),
+                new Case("auth me user ok", HttpMethod.GET, "/api/auth/me", Auth.USER, HttpStatus.OK, true),
                 new Case("public GET permitAll", HttpMethod.GET, "/api/public/x", Auth.NONE, HttpStatus.OK, true),
                 new Case("events GET permitAll", HttpMethod.GET, "/api/events/123", Auth.NONE, HttpStatus.OK, true),
                 new Case("salary calculate POST permitAll", HttpMethod.POST, "/api/salary/calculate", Auth.NONE, HttpStatus.OK, true),


### PR DESCRIPTION
 This part finalizes the source-specific ingest flow and closes the remaining integration gaps. AMQP routing for job ingest is now split by source instead of using a
  single shared job-url route, which makes queue handling, retries, and listener ownership explicit across JUSTJOIN, NOFLUFFJOBS, SOLIDJOBS, and THEPROTOCOL. Source PRACUJ has also idividual queue

  SOLIDJOBS is now fully wired through its own dedicated path from crawler to queue to backend consumer. On top of that, both URL publishing in agent-crawler and API
  fetching in backend are throttled to 2 requests per second, which should make the flow more stable and reduce the risk of rate limiting.

  This branch ending also aligns auth behavior across backend, gateway, and frontend. /api/auth/me now correctly requires authentication, and the list of public auth
  endpoints is handled consistently across all three layers.

  Config-wise, the branch also cleans up and aligns related YAML settings, including health probe exposure and scheduler timing needed for the updated ingest flow.

