### PR TITLE
CHB-48: NFJ ingest and auth hardening

### DIFF
--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumeService.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumeService.java
@@ -107,6 +107,11 @@ public class JobUrlConsumeService {
             return;
         }
 
+        if (source == JobSource.NOFLUFFJOBS && sc == 429) {
+            logRequeue("[ingest] NFJ rate limited HTTP {} for {}, long backoff", sc, url);
+            throw new NfjRateLimitException("NFJ rate limit HTTP " + sc + " for " + url);
+        }
+
         if (sc == 408 || sc == 425 || sc == 429 || (sc >= 500 && sc < 600)) {
             logRequeue("[ingest] transient HTTP {} for {} (source={}), requeue", sc, url, source);
             throw new ImmediateRequeueAmqpException("HTTP " + sc + " for " + url);
@@ -129,7 +134,7 @@ public class JobUrlConsumeService {
 
     private void handleNofluff(String url) throws IOException {
         String externalId = lastPath(url);
-        String html = fetchNofluffHtml(url);
+        String html = fetchNofluffHtml(url, externalId);
 
         if (nfjHtmlParser.isExpired(html)) {
             publishInactive(JobSource.NOFLUFFJOBS, externalId, normalizeUrl(url));
@@ -142,7 +147,7 @@ public class JobUrlConsumeService {
             return;
         }
 
-        String json = fetchNofluffJson(externalId);
+        String json = fetchNofluffJson(externalId, url);
         ParsedExternalOffer parsedOffer = nofluffParser.parseFromApiJson(externalId, json, url);
         externalOfferPublisher.publish(ExternalOfferMessageMapper.fromParsedOffer(parsedOffer));
         logOk("[ingest] NFJ publish OK: {}", url);
@@ -255,26 +260,54 @@ public class JobUrlConsumeService {
                 .outerHtml();
     }
 
-    private String fetchNofluffHtml(String url) throws IOException {
+    private String fetchNofluffHtml(String url, String externalId) throws IOException {
         NFJ_FETCH_LIMITER.acquire();
-        return fetchHtml(url, "https://nofluffjobs.com/");
+        long startedAt = System.currentTimeMillis();
+        try {
+            String html = fetchHtml(url, "https://nofluffjobs.com/");
+            log.debug("[ingest] NFJ html fetch OK externalId={} tookMs={} url={}",
+                    externalId, System.currentTimeMillis() - startedAt, url);
+            return html;
+        } catch (HttpStatusException ex) {
+            log.warn("[ingest] NFJ html fetch HTTP {} externalId={} tookMs={} url={}",
+                    ex.getStatusCode(), externalId, System.currentTimeMillis() - startedAt, url);
+            throw ex;
+        } catch (IOException ex) {
+            log.warn("[ingest] NFJ html fetch I/O error externalId={} tookMs={} url={} error={}",
+                    externalId, System.currentTimeMillis() - startedAt, url, ex.toString());
+            throw ex;
+        }
     }
 
-    private String fetchNofluffJson(String externalId) throws IOException {
+    private String fetchNofluffJson(String externalId, String url) throws IOException {
         String apiUrl = "https://nofluffjobs.com/api/posting/" + externalId
                 + "?salaryCurrency=PLN&salaryPeriod=month&region=pl&language=pl-PL";
 
         NFJ_FETCH_LIMITER.acquire();
 
-        return Jsoup.connect(apiUrl)
-                .userAgent(BROWSER_UA)
-                .referrer("https://nofluffjobs.com/")
-                .ignoreContentType(true)
-                .header("Accept", "application/json")
-                .timeout(15_000)
-                .get()
-                .body()
-                .text();
+        long startedAt = System.currentTimeMillis();
+        try {
+            String json = Jsoup.connect(apiUrl)
+                    .userAgent(BROWSER_UA)
+                    .referrer("https://nofluffjobs.com/")
+                    .ignoreContentType(true)
+                    .header("Accept", "application/json")
+                    .timeout(15_000)
+                    .get()
+                    .body()
+                    .text();
+            log.debug("[ingest] NFJ json fetch OK externalId={} tookMs={} url={}",
+                    externalId, System.currentTimeMillis() - startedAt, url);
+            return json;
+        } catch (HttpStatusException ex) {
+            log.warn("[ingest] NFJ json fetch HTTP {} externalId={} tookMs={} url={}",
+                    ex.getStatusCode(), externalId, System.currentTimeMillis() - startedAt, url);
+            throw ex;
+        } catch (IOException ex) {
+            log.warn("[ingest] NFJ json fetch I/O error externalId={} tookMs={} url={} error={}",
+                    externalId, System.currentTimeMillis() - startedAt, url, ex.toString());
+            throw ex;
+        }
     }
 
     private void handleInterruptedIo(String url) {

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumer.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumer.java
@@ -1,6 +1,7 @@
 package com.milosz.podsiadly.careerhub.agentcrawler.ingest.mq;
 
 import com.milosz.podsiadly.careerhub.agentcrawler.mq.UrlMessage;
+import com.milosz.podsiadly.careerhub.agentcrawler.job.domain.JobSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
@@ -68,15 +69,50 @@ public class JobUrlConsumer {
     private void onMessage(UrlMessage msg, Message message) throws Exception {
         String messageId = resolveMessageId(message);
         int attempt = getAttempt(message);
+        JobSource source = resolveSource(msg);
 
         try {
             consumeService.consume(msg);
         } catch (ImmediateRequeueAmqpException ex) {
-            retryPublisher.retry(msg, attempt, ex, messageId);
+            logRetry(source, msg, messageId, attempt, ex, true);
+            retryPublisher.retryWithPolicy(msg, attempt, ex, messageId);
         } catch (AmqpRejectAndDontRequeueException ex) {
+            logRetry(source, msg, messageId, attempt, ex, false);
             retryPublisher.dlq(msg, ex, messageId, attempt);
         } catch (Exception ex) {
-            retryPublisher.retry(msg, attempt, ex, messageId);
+            logRetry(source, msg, messageId, attempt, ex, true);
+            retryPublisher.retryWithPolicy(msg, attempt, ex, messageId);
+        }
+    }
+
+    private void logRetry(JobSource source, UrlMessage msg, String messageId, int attempt, Exception ex, boolean willRetry) {
+        if (source != JobSource.NOFLUFFJOBS) {
+            return;
+        }
+
+        String action = willRetry ? "retry" : "dlq";
+        String errorMessage = ex.getMessage();
+        if (errorMessage != null && errorMessage.length() > 300) {
+            errorMessage = errorMessage.substring(0, 300);
+        }
+
+        log.warn("[job-url] NFJ {} messageId={} attempt={} error={} message={} url={}",
+                action,
+                messageId,
+                attempt,
+                ex.getClass().getSimpleName(),
+                errorMessage,
+                msg != null ? msg.url() : null);
+    }
+
+    private static JobSource resolveSource(UrlMessage msg) {
+        if (msg == null || msg.source() == null || msg.source().isBlank()) {
+            return JobSource.JUSTJOIN;
+        }
+        try {
+            return JobSource.valueOf(msg.source().trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return JobSource.JUSTJOIN;
         }
     }
 

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlRetryPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlRetryPublisher.java
@@ -17,12 +17,6 @@ public class JobUrlRetryPublisher {
     private final RabbitTemplate rabbit;
     private final IngestMessagingProperties props;
 
-    public void retry(UrlMessage msg, int attempt, Exception ex, String messageId) {
-        String source = props.resolveExternalOfferSource(msg.source());
-        String routing = routingForAttempt(source, attempt);
-        publish(msg, routing, attempt + 1, ex, messageId);
-    }
-
     public void dlq(UrlMessage msg, Exception ex, String messageId, int attempt) {
         String source = props.resolveExternalOfferSource(msg.source());
         publish(msg, props.urlsDlqRouting(source), attempt, ex, messageId);
@@ -54,9 +48,39 @@ public class JobUrlRetryPublisher {
     }
 
     private String routingForAttempt(String source, int attempt) {
+        if (attempt < 0) {
+            return props.urlsDlqRouting(source);
+        }
         if (attempt == 0) return props.urlsRetry1Routing(source);
         if (attempt == 1) return props.urlsRetry5Routing(source);
         if (attempt == 2) return props.urlsRetry30Routing(source);
         return props.urlsDlqRouting(source);
+    }
+
+    public void retryWithPolicy(UrlMessage msg, int attempt, Exception ex, String messageId) {
+        String source = props.resolveExternalOfferSource(msg.source());
+        String routing = routingForException(source, attempt, ex);
+        int nextAttempt = nextAttemptForException(attempt, ex);
+        publish(msg, routing, nextAttempt, ex, messageId);
+    }
+
+    private String routingForException(String source, int attempt, Exception ex) {
+        if (ex instanceof NfjRateLimitException) {
+            if (attempt <= 0) return props.urlsRetry5Routing(source);
+            if (attempt == 1) return props.urlsRetry30Routing(source);
+            return props.urlsDlqRouting(source);
+        }
+
+        return routingForAttempt(source, attempt);
+    }
+
+    private int nextAttemptForException(int attempt, Exception ex) {
+        if (ex instanceof NfjRateLimitException) {
+            if (attempt <= 0) return 2;
+            if (attempt == 1) return 3;
+            return attempt;
+        }
+
+        return attempt + 1;
     }
 }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/NfjRateLimitException.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/NfjRateLimitException.java
@@ -1,0 +1,10 @@
+package com.milosz.podsiadly.careerhub.agentcrawler.ingest.mq;
+
+import org.springframework.amqp.ImmediateRequeueAmqpException;
+
+public class NfjRateLimitException extends ImmediateRequeueAmqpException {
+
+    public NfjRateLimitException(String message) {
+        super(message);
+    }
+}

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/NfjCrawlerScheduler.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/nfj/NfjCrawlerScheduler.java
@@ -1,13 +1,19 @@
 package com.milosz.podsiadly.careerhub.agentcrawler.nfj;
 
+import com.milosz.podsiadly.careerhub.agentcrawler.config.IngestMessagingProperties;
 import com.milosz.podsiadly.careerhub.agentcrawler.mq.NfjJobPublisher;
 import com.milosz.podsiadly.careerhub.agentcrawler.nfj.api.NfjApiClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -18,8 +24,16 @@ public class NfjCrawlerScheduler {
 
     private final NfjApiClient apiClient;
     private final NfjJobPublisher publisher;
+    private final AmqpAdmin amqpAdmin;
+    private final IngestMessagingProperties messagingProperties;
 
     private final AtomicLong totalSentSinceStart = new AtomicLong(0);
+
+    @Value("${jobs.ingest.nfj.max-url-backlog-before-skip:5000}")
+    private long maxUrlBacklogBeforeSkip;
+
+    @Value("${jobs.ingest.nfj.max-external-offers-backlog-before-skip:5000}")
+    private long maxExternalOffersBacklogBeforeSkip;
 
     private static final String[] NFJ_CATEGORY_SLUGS = {
             "artificial-intelligence",
@@ -49,6 +63,9 @@ public class NfjCrawlerScheduler {
     )
     public void runPeriodic() {
         log.info("[agent-nfj] periodic crawl triggered");
+        if (shouldSkipDueToBacklog()) {
+            return;
+        }
         runOnce();
     }
 
@@ -85,6 +102,87 @@ public class NfjCrawlerScheduler {
 
         } catch (Exception e) {
             log.error("[agent-nfj] runOnce failed: {}", e.toString(), e);
+        }
+    }
+
+    private boolean shouldSkipDueToBacklog() {
+        Map<String, Long> backlog = currentBacklogSnapshot();
+        long urlBacklog = sum(backlog,
+                messagingProperties.urlsQueue("NOFLUFFJOBS"),
+                messagingProperties.urlsRetry1Queue("NOFLUFFJOBS"),
+                messagingProperties.urlsRetry5Queue("NOFLUFFJOBS"),
+                messagingProperties.urlsRetry30Queue("NOFLUFFJOBS"));
+        long externalOffersBacklog = sum(backlog,
+                messagingProperties.externalOffersQueue("NOFLUFFJOBS"),
+                messagingProperties.externalOffersRetry1Queue("NOFLUFFJOBS"),
+                messagingProperties.externalOffersRetry5Queue("NOFLUFFJOBS"),
+                messagingProperties.externalOffersRetry30Queue("NOFLUFFJOBS"));
+
+        boolean skip = urlBacklog >= maxUrlBacklogBeforeSkip
+                || externalOffersBacklog >= maxExternalOffersBacklogBeforeSkip;
+
+        if (skip) {
+            log.warn("[agent-nfj] skipping run because backlog is too high urlBacklog={} externalOffersBacklog={} snapshot={}",
+                    urlBacklog, externalOffersBacklog, backlog);
+        } else {
+            log.info("[agent-nfj] backlog check OK urlBacklog={} externalOffersBacklog={}",
+                    urlBacklog, externalOffersBacklog);
+        }
+
+        return skip;
+    }
+
+    private Map<String, Long> currentBacklogSnapshot() {
+        Map<String, Long> backlog = new LinkedHashMap<>();
+        readQueueDepth(backlog, messagingProperties.urlsQueue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.urlsRetry1Queue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.urlsRetry5Queue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.urlsRetry30Queue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.externalOffersQueue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.externalOffersRetry1Queue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.externalOffersRetry5Queue("NOFLUFFJOBS"));
+        readQueueDepth(backlog, messagingProperties.externalOffersRetry30Queue("NOFLUFFJOBS"));
+        return backlog;
+    }
+
+    private void readQueueDepth(Map<String, Long> backlog, String queueName) {
+        PropertiesSnapshot props = queueDepth(queueName);
+        backlog.put(queueName, props.messageCount());
+    }
+
+    private PropertiesSnapshot queueDepth(String queueName) {
+        try {
+            QueueProperties properties = new QueueProperties(amqpAdmin.getQueueProperties(queueName));
+            return new PropertiesSnapshot(properties.messageCount());
+        } catch (Exception ex) {
+            log.warn("[agent-nfj] cannot read queue depth for {}: {}", queueName, ex.toString());
+            return new PropertiesSnapshot(0L);
+        }
+    }
+
+    private long sum(Map<String, Long> backlog, String... queueNames) {
+        long total = 0L;
+        for (String queueName : queueNames) {
+            total += backlog.getOrDefault(queueName, 0L);
+        }
+        return total;
+    }
+
+    private record PropertiesSnapshot(long messageCount) {
+    }
+
+    private record QueueProperties(Properties raw) {
+        private static final String QUEUE_MESSAGE_COUNT_KEY = "QUEUE_MESSAGE_COUNT";
+
+        long messageCount() {
+            if (raw == null) {
+                return 0L;
+            }
+            Object value = raw.get(QUEUE_MESSAGE_COUNT_KEY);
+            if (value instanceof Number number) {
+                return number.longValue();
+            }
+            return 0L;
         }
     }
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/EmailVerificationService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/EmailVerificationService.java
@@ -30,9 +30,10 @@ public class EmailVerificationService {
         if (user.isEmailVerified()) return;
 
         String tokenValue = generateToken();
+        String tokenHash = TokenHashing.sha256(tokenValue);
 
         EmailVerificationToken token = EmailVerificationToken.builder()
-                .token(tokenValue)
+                .token(tokenHash)
                 .user(user)
                 .expiresAt(LocalDateTime.now().plusHours(expHours))
                 .used(false)
@@ -50,7 +51,7 @@ public class EmailVerificationService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid token");
         }
 
-        EmailVerificationToken token = tokens.findByToken(tokenValue)
+        EmailVerificationToken token = tokens.findByToken(TokenHashing.sha256(tokenValue))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid token"));
 
         if (token.isUsed() || token.getExpiresAt().isBefore(LocalDateTime.now())) {

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/PasswordResetService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/PasswordResetService.java
@@ -48,10 +48,13 @@ public class PasswordResetService {
             return;
         }
 
+        tokens.invalidateAllActiveForUser(user.getId(), LocalDateTime.now());
+
         String tokenValue = generateToken();
+        String tokenHash = TokenHashing.sha256(tokenValue);
 
         PasswordResetToken token = PasswordResetToken.builder()
-                .token(tokenValue)
+                .token(tokenHash)
                 .user(user)
                 .expiresAt(LocalDateTime.now().plusHours(tokenExpHours))
                 .used(false)
@@ -72,7 +75,7 @@ public class PasswordResetService {
             throw new ResponseStatusException(BAD_REQUEST, "Password is required");
         }
 
-        PasswordResetToken token = tokens.findByToken(req.token())
+        PasswordResetToken token = tokens.findByToken(TokenHashing.sha256(req.token()))
                 .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Invalid reset token"));
 
         if (token.isUsed() || token.getExpiresAt().isBefore(LocalDateTime.now())) {
@@ -83,6 +86,7 @@ public class PasswordResetService {
         user.setPassword(passwordEncoder.encode(req.newPassword()));
 
         token.setUsed(true);
+        tokens.invalidateAllActiveForUser(user.getId(), LocalDateTime.now());
     }
 
     private String generateToken() {

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/PasswordResetTokenRepository.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/PasswordResetTokenRepository.java
@@ -1,6 +1,7 @@
 package com.milosz.podsiadly.backend.domain.loginandregister;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,14 @@ public interface PasswordResetTokenRepository extends JpaRepository<PasswordRese
     Optional<PasswordResetToken> findTopByUserIdOrderByCreatedAtDesc(String userId);
 
     long countByUserIdAndCreatedAtAfter(String userId, LocalDateTime after);
+
+    @Modifying
+    @Query("""
+    update PasswordResetToken t
+       set t.used = true
+     where t.user.id = :userId
+       and t.used = false
+       and t.expiresAt > :now
+""")
+    int invalidateAllActiveForUser(@Param("userId") String userId, @Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/TokenHashing.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/TokenHashing.java
@@ -1,0 +1,30 @@
+package com.milosz.podsiadly.backend.domain.loginandregister;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class TokenHashing {
+
+    private TokenHashing() {
+    }
+
+    public static String sha256(String rawToken) {
+        if (rawToken == null || rawToken.isBlank()) {
+            throw new IllegalArgumentException("Token must not be blank");
+        }
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+                hex.append(Character.forDigit(b & 0xF, 16));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 algorithm unavailable", ex);
+        }
+    }
+}

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/mail/MailConsumer.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/loginandregister/mail/MailConsumer.java
@@ -1,8 +1,8 @@
 package com.milosz.podsiadly.backend.domain.loginandregister.mail;
 
 import com.milosz.podsiadly.backend.domain.loginandregister.EmailVerificationTokenRepository;
-import com.milosz.podsiadly.backend.domain.loginandregister.mail.MailService;
 import com.milosz.podsiadly.backend.domain.loginandregister.PasswordResetTokenRepository;
+import com.milosz.podsiadly.backend.domain.loginandregister.TokenHashing;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
@@ -65,25 +65,25 @@ public class MailConsumer {
     }
 
     private void handleVerify(MailSendCommand cmd) {
-        var tokenOpt = verificationTokens.findByToken(cmd.token());
+        var tokenOpt = verificationTokens.findByToken(TokenHashing.sha256(cmd.token()));
         if (tokenOpt.isEmpty()) return;
 
         var token = tokenOpt.get();
         if (token.isUsed() || token.getExpiresAt().isBefore(LocalDateTime.now())) return;
         if (token.getUser().isEmailVerified()) return;
 
-        String link = frontendUrl + "/auth/verify?token=" + token.getToken();
+        String link = frontendUrl + "/auth/verify?token=" + cmd.token();
         mailService.sendEmailVerification(token.getUser().getEmail(), link);
     }
 
     private void handleReset(MailSendCommand cmd) {
-        var tokenOpt = resetTokens.findByToken(cmd.token());
+        var tokenOpt = resetTokens.findByToken(TokenHashing.sha256(cmd.token()));
         if (tokenOpt.isEmpty()) return;
 
         var token = tokenOpt.get();
         if (token.isUsed() || token.getExpiresAt().isBefore(LocalDateTime.now())) return;
 
-        String link = frontendUrl + "/auth/reset-password?token=" + token.getToken();
+        String link = frontendUrl + "/auth/reset-password?token=" + cmd.token();
         mailService.sendPasswordResetEmail(token.getUser().getEmail(), link);
     }
 

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/myapplication/ApplicationService.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/myapplication/ApplicationService.java
@@ -124,7 +124,7 @@ public class ApplicationService {
 
     @Transactional
     public ApplicationDetailDto updateStatus(Long id, String userId, ApplicationStatus newStatus) {
-        var a = apps.findAccessible(id, userId)
+        var a = apps.findManageableByOwner(id, userId)
                 .orElseThrow(() -> new IllegalArgumentException("Application not found or forbidden."));
         a.setStatus(newStatus);
         return toDetailDto(a);

--- a/backend/src/main/java/com/milosz/podsiadly/backend/domain/myapplication/JobApplicationRepository.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/domain/myapplication/JobApplicationRepository.java
@@ -42,4 +42,16 @@ public interface JobApplicationRepository extends JpaRepository<JobApplication, 
         )
     """)
     Optional<JobApplication> findAccessible(@Param("appId") Long appId, @Param("userId") String userId);
+
+    @Query("""
+      select a from JobApplication a
+      left join a.offer o
+      left join com.milosz.podsiadly.backend.job.domain.JobOfferOwner ow on ow.jobOffer = o
+      where a.id = :appId
+        and (
+             (o is not null and ow.user.id = :ownerId)
+             or (o is null and a.offerOwnerIdSnapshot = :ownerId)
+        )
+    """)
+    Optional<JobApplication> findManageableByOwner(@Param("appId") Long appId, @Param("ownerId") String ownerId);
 }


### PR DESCRIPTION

  ## Summary

  This branch contains three focused fixes:

  1. Hardened NFJ ingest retry handling in `agent-crawler`
  2. Restricted application status updates to offer owners only
  3. Secured verification and password reset tokens by hashing them in storage

  ## Commits

  ### `fix(agent-crawler): harden NFJ ingest retry flow`
  - add backlog guard in `NfjCrawlerScheduler` to stop flooding NFJ queues when backlog is already high
  - add NFJ-specific retry diagnostics in `JobUrlConsumer`
  - add stage-level logging for NFJ HTML and JSON fetches in `JobUrlConsumeService`
  - introduce `NfjRateLimitException` and route HTTP 429 through longer backoff instead of immediate retry churn
  - remove obsolete retry path and keep retry handling centralized in policy-based flow

  ### `fix(backend): restrict application status updates to owners`
  - add owner-only repository lookup for application status management
  - change `ApplicationService.updateStatus(...)` to allow status updates only for offer owners
  - keep `findAccessible(...)` for read access only

  ### `fix(backend): hash verification and reset tokens`
  - store email verification and password reset tokens as SHA-256 hashes instead of plaintext
  - resolve incoming tokens by hash during verification and password reset
  - update mail sending flow to keep raw tokens only in the outgoing link, not in persistence
  - invalidate previous active password reset tokens before issuing a new one
  - invalidate remaining active reset tokens after a successful password reset