### PR TITLE
CHB-48 part 2: Reduce NFJ 429 Storms And Harden Solid Sitemap Fetching

### DIFF
--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/IngestMessagingProperties.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/IngestMessagingProperties.java
@@ -56,6 +56,7 @@ public class IngestMessagingProperties {
         private java.time.Duration after1 = java.time.Duration.ofMinutes(1);
         private java.time.Duration after5 = java.time.Duration.ofMinutes(5);
         private java.time.Duration after30 = java.time.Duration.ofMinutes(30);
+        private double jitterFactor = 0.20d;
     }
 
     @Getter @Setter

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/RabbitConfig.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/config/RabbitConfig.java
@@ -46,17 +46,14 @@ public class RabbitConfig {
         for (String source : props.externalOfferSources()) {
             Queue primaryQueue = QueueBuilder.durable(props.urlsQueue(source)).build();
             Queue retry1Queue = QueueBuilder.durable(props.urlsRetry1Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter1().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.urlsRouting(source))
                     .build();
             Queue retry5Queue = QueueBuilder.durable(props.urlsRetry5Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter5().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.urlsRouting(source))
                     .build();
             Queue retry30Queue = QueueBuilder.durable(props.urlsRetry30Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter30().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.urlsRouting(source))
                     .build();
@@ -204,17 +201,14 @@ public class RabbitConfig {
         for (String source : props.externalOfferSources()) {
             Queue primaryQueue = QueueBuilder.durable(props.externalOffersQueue(source)).build();
             Queue retry1Queue = QueueBuilder.durable(props.externalOffersRetry1Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter1().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.externalOffersRouting(source))
                     .build();
             Queue retry5Queue = QueueBuilder.durable(props.externalOffersRetry5Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter5().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.externalOffersRouting(source))
                     .build();
             Queue retry30Queue = QueueBuilder.durable(props.externalOffersRetry30Queue(source))
-                    .withArgument("x-message-ttl", props.getRetry().getAfter30().toMillis())
                     .withArgument("x-dead-letter-exchange", props.getExchange())
                     .withArgument("x-dead-letter-routing-key", props.externalOffersRouting(source))
                     .build();

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumeService.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlConsumeService.java
@@ -25,7 +25,9 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,12 +41,13 @@ public class JobUrlConsumeService {
                     "(KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
 
     private static final RateLimiter JJ_FETCH_LIMITER = RateLimiter.create(2.0d);
-    private static final RateLimiter NFJ_FETCH_LIMITER = RateLimiter.create(0.5d);
     private static final RateLimiter TP_FETCH_LIMITER = RateLimiter.create(1.0d);
     private static final RateLimiter SOLID_FETCH_LIMITER = RateLimiter.create(2.0d);
     private static final Pattern TP_OFFER_ID = Pattern.compile(
             "(?:,oferta,|%2Coferta%2C)([0-9a-fA-F\\-]{36})"
     );
+    private final RateLimiter nfjFetchLimiter = RateLimiter.create(0.25d);
+    private final AtomicLong nfjSuspendedUntilEpochMs = new AtomicLong(0L);
 
     private final JustJoinParser justJoinParser;
     private final NofluffParser nofluffParser;
@@ -55,6 +58,12 @@ public class JobUrlConsumeService {
 
     @Value("${ingest.logging.quiet:true}")
     private boolean quietLogging;
+
+    @Value("${jobs.ingest.nfj.detail-fetch-rate-per-second:0.25}")
+    private double nfjDetailFetchRatePerSecond;
+
+    @Value("${jobs.ingest.nfj.cooldown-after-429:PT15M}")
+    private Duration nfjCooldownAfter429;
 
     public void consume(UrlMessage msg) throws Exception {
         final String url = msg.url();
@@ -108,6 +117,7 @@ public class JobUrlConsumeService {
         }
 
         if (source == JobSource.NOFLUFFJOBS && sc == 429) {
+            activateNfjCooldown(url);
             logRequeue("[ingest] NFJ rate limited HTTP {} for {}, long backoff", sc, url);
             throw new NfjRateLimitException("NFJ rate limit HTTP " + sc + " for " + url);
         }
@@ -134,6 +144,7 @@ public class JobUrlConsumeService {
 
     private void handleNofluff(String url) throws IOException {
         String externalId = lastPath(url);
+        ensureNfjNotSuspended(url);
         String html = fetchNofluffHtml(url, externalId);
 
         if (nfjHtmlParser.isExpired(html)) {
@@ -147,6 +158,7 @@ public class JobUrlConsumeService {
             return;
         }
 
+        ensureNfjNotSuspended(url);
         String json = fetchNofluffJson(externalId, url);
         ParsedExternalOffer parsedOffer = nofluffParser.parseFromApiJson(externalId, json, url);
         externalOfferPublisher.publish(ExternalOfferMessageMapper.fromParsedOffer(parsedOffer));
@@ -261,7 +273,8 @@ public class JobUrlConsumeService {
     }
 
     private String fetchNofluffHtml(String url, String externalId) throws IOException {
-        NFJ_FETCH_LIMITER.acquire();
+        nfjFetchLimiter.setRate(nfjDetailFetchRatePerSecond);
+        nfjFetchLimiter.acquire();
         long startedAt = System.currentTimeMillis();
         try {
             String html = fetchHtml(url, "https://nofluffjobs.com/");
@@ -283,7 +296,8 @@ public class JobUrlConsumeService {
         String apiUrl = "https://nofluffjobs.com/api/posting/" + externalId
                 + "?salaryCurrency=PLN&salaryPeriod=month&region=pl&language=pl-PL";
 
-        NFJ_FETCH_LIMITER.acquire();
+        nfjFetchLimiter.setRate(nfjDetailFetchRatePerSecond);
+        nfjFetchLimiter.acquire();
 
         long startedAt = System.currentTimeMillis();
         try {
@@ -318,6 +332,29 @@ public class JobUrlConsumeService {
     private void handleIoException(IOException e, String url) {
         logRequeue("[ingest] I/O error for {}, requeue: {}", url, e.toString());
         throw new ImmediateRequeueAmqpException("I/O error for " + url);
+    }
+
+    private void ensureNfjNotSuspended(String url) {
+        long suspendedUntil = nfjSuspendedUntilEpochMs.get();
+        long now = System.currentTimeMillis();
+        if (suspendedUntil <= now) {
+            return;
+        }
+
+        long remainingMs = suspendedUntil - now;
+        logRequeue("[ingest] NFJ cooldown active remainingMs={} for {}", remainingMs, url);
+        throw new NfjRateLimitException("NFJ cooldown active for " + remainingMs + "ms for " + url);
+    }
+
+    private void activateNfjCooldown(String url) {
+        long cooldownMs = Math.max(1_000L, nfjCooldownAfter429.toMillis());
+        long newSuspendedUntil = System.currentTimeMillis() + cooldownMs;
+        long effectiveSuspendedUntil = nfjSuspendedUntilEpochMs.updateAndGet(current ->
+                Math.max(current, newSuspendedUntil));
+        log.warn("[ingest] NFJ cooldown activated untilEpochMs={} durationMs={} url={}",
+                effectiveSuspendedUntil,
+                cooldownMs,
+                url);
     }
 
     private String externalIdFor(JobSource source, String url) {

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlRetryPublisher.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/ingest/mq/JobUrlRetryPublisher.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.UUID;
 
 @Slf4j
@@ -26,6 +28,7 @@ public class JobUrlRetryPublisher {
         String effectiveMessageId = messageId != null && !messageId.isBlank()
                 ? messageId
                 : UUID.randomUUID().toString();
+        Long delayMs = delayForRouting(routing);
 
         rabbit.convertAndSend(props.getExchange(), routing, msg, message -> {
             var p = message.getMessageProperties();
@@ -40,11 +43,15 @@ public class JobUrlRetryPublisher {
             if (msgText != null) {
                 p.setHeader("x-error-message", msgText);
             }
+            if (delayMs != null) {
+                p.setExpiration(Long.toString(delayMs));
+                p.setHeader("x-delay-ms", delayMs);
+            }
             return message;
         });
 
-        log.warn("[job-url] routed messageId={} source={} url={} routing={} attempt={}",
-                effectiveMessageId, msg.source(), msg.url(), routing, nextAttempt);
+        log.warn("[job-url] routed messageId={} source={} url={} routing={} attempt={} delayMs={}",
+                effectiveMessageId, msg.source(), msg.url(), routing, nextAttempt, delayMs);
     }
 
     private String routingForAttempt(String source, int attempt) {
@@ -82,5 +89,41 @@ public class JobUrlRetryPublisher {
         }
 
         return attempt + 1;
+    }
+
+    private Long delayForRouting(String routing) {
+        Duration baseDelay = baseDelayForRouting(routing);
+        if (baseDelay == null) {
+            return null;
+        }
+        return jitteredDelayMs(baseDelay);
+    }
+
+    private Duration baseDelayForRouting(String routing) {
+        if (routing == null) {
+            return null;
+        }
+        if (routing.startsWith(props.getRouting().getUrlsRetry1())) {
+            return props.getRetry().getAfter1();
+        }
+        if (routing.startsWith(props.getRouting().getUrlsRetry5())) {
+            return props.getRetry().getAfter5();
+        }
+        if (routing.startsWith(props.getRouting().getUrlsRetry30())) {
+            return props.getRetry().getAfter30();
+        }
+        return null;
+    }
+
+    private long jitteredDelayMs(Duration baseDelay) {
+        long baseMs = Math.max(1_000L, baseDelay.toMillis());
+        double jitterFactor = Math.max(0.0d, Math.min(props.getRetry().getJitterFactor(), 0.95d));
+        if (jitterFactor == 0.0d) {
+            return baseMs;
+        }
+
+        long minMs = Math.max(1_000L, (long) Math.floor(baseMs * (1.0d - jitterFactor)));
+        long maxMs = Math.max(minMs, (long) Math.ceil(baseMs * (1.0d + jitterFactor)));
+        return ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
     }
 }

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/SolidCrawlerScheduler.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/SolidCrawlerScheduler.java
@@ -31,7 +31,7 @@ public class SolidCrawlerScheduler {
             Set<String> urls = solidApiClient.fetchOfferUrlsFromSitemap();
 
             if (urls.isEmpty()) {
-                log.warn("[agent-solid] sitemap returned NO urls");
+                log.warn("[agent-solid] sitemap fetch produced no offer urls; upstream may be unavailable or blocking requests");
                 return;
             }
 

--- a/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/api/SolidApiClient.java
+++ b/agent-crawler/src/main/java/com/milosz/podsiadly/careerhub/agentcrawler/solid/api/SolidApiClient.java
@@ -5,13 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -20,6 +23,13 @@ import org.w3c.dom.NodeList;
 @Component
 @RequiredArgsConstructor
 public class SolidApiClient {
+
+    private static final String BROWSER_UA =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                    "(KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
+    private static final int MAX_SITEMAP_ATTEMPTS = 4;
+    private static final long INITIAL_BACKOFF_MS = 2_000L;
+    private static final long MAX_BACKOFF_MS = 20_000L;
 
     private final RestTemplate restTemplate;
 
@@ -36,25 +46,84 @@ public class SolidApiClient {
     public Set<String> fetchOfferUrlsFromSitemap(String sitemapUrl) {
         log.info("[solid-api] fetching sitemap from {}", sitemapUrl);
 
-        try {
-            ResponseEntity<String> response =
-                    restTemplate.getForEntity(sitemapUrl, String.class);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(
+                MediaType.APPLICATION_XML,
+                MediaType.TEXT_XML,
+                MediaType.TEXT_HTML,
+                MediaType.ALL
+        ));
+        headers.setAcceptLanguageAsLocales(List.of(java.util.Locale.forLanguageTag("pl-PL"), java.util.Locale.ENGLISH));
+        headers.set("User-Agent", BROWSER_UA);
+        headers.set("Referer", baseUrl + "/");
+        headers.set("Cache-Control", "no-cache");
+        headers.set("Pragma", "no-cache");
 
-            log.info("[solid-api] sitemap status={} contentType={}",
-                    response.getStatusCode(), response.getHeaders().getContentType());
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        long backoffMs = INITIAL_BACKOFF_MS;
 
-            String body = response.getBody();
-            if (body == null || body.isBlank()) {
-                log.warn("[solid-api] sitemap body is null/blank");
-                return Set.of();
+        for (int attempt = 1; attempt <= MAX_SITEMAP_ATTEMPTS; attempt++) {
+            long startedAt = System.currentTimeMillis();
+            try {
+                ResponseEntity<String> response = restTemplate.exchange(
+                        sitemapUrl,
+                        HttpMethod.GET,
+                        entity,
+                        String.class
+                );
+
+                log.info("[solid-api] sitemap attempt={}/{} status={} contentType={} tookMs={}",
+                        attempt,
+                        MAX_SITEMAP_ATTEMPTS,
+                        response.getStatusCode(),
+                        response.getHeaders().getContentType(),
+                        System.currentTimeMillis() - startedAt);
+
+                String body = response.getBody();
+                if (body == null || body.isBlank()) {
+                    log.warn("[solid-api] sitemap body is null/blank attempt={}/{}", attempt, MAX_SITEMAP_ATTEMPTS);
+                    return Set.of();
+                }
+
+                return extractOfferUrls(body);
+            } catch (HttpStatusCodeException ex) {
+                int status = ex.getStatusCode().value();
+                String bodySnippet = abbreviateBody(ex.getResponseBodyAsString());
+                boolean retryable = status == 429 || status == 503 || status >= 500;
+
+                log.warn("[solid-api] sitemap HTTP {} attempt={}/{} tookMs={} retryable={} body={}",
+                        status,
+                        attempt,
+                        MAX_SITEMAP_ATTEMPTS,
+                        System.currentTimeMillis() - startedAt,
+                        retryable,
+                        bodySnippet);
+
+                if (!retryable || attempt == MAX_SITEMAP_ATTEMPTS) {
+                    log.warn("[solid-api] sitemap fetch exhausted after status={} attempts={}", status, attempt, ex);
+                    return Set.of();
+                }
+
+                sleepWithJitter(backoffMs);
+                backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+            } catch (Exception e) {
+                log.warn("[solid-api] sitemap fetch failed attempt={}/{} tookMs={} error={}",
+                        attempt,
+                        MAX_SITEMAP_ATTEMPTS,
+                        System.currentTimeMillis() - startedAt,
+                        e.toString(),
+                        e);
+
+                if (attempt == MAX_SITEMAP_ATTEMPTS) {
+                    return Set.of();
+                }
+
+                sleepWithJitter(backoffMs);
+                backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
             }
-
-            return extractOfferUrls(body);
-
-        } catch (Exception e) {
-            log.warn("[solid-api] failed to fetch sitemap: {}", e.toString(), e);
-            return Set.of();
         }
+
+        return Set.of();
     }
 
     public String fetchOfferJsonByOfferUrl(String offerUrl) {
@@ -146,5 +215,30 @@ public class SolidApiClient {
         }
 
         return urls;
+    }
+
+    private static void sleepWithJitter(long baseMs) {
+        long jitter = ThreadLocalRandom.current().nextLong(250L, 1250L);
+        long sleepMs = Math.max(250L, baseMs + jitter);
+        try {
+            Thread.sleep(sleepMs);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static String abbreviateBody(String body) {
+        if (body == null) {
+            return null;
+        }
+        String normalized = body
+                .replace("\r", " ")
+                .replace("\n", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+        if (normalized.length() <= 240) {
+            return normalized;
+        }
+        return normalized.substring(0, 240);
     }
 }

--- a/agent-crawler/src/main/resources/application-aws.yml
+++ b/agent-crawler/src/main/resources/application-aws.yml
@@ -66,6 +66,11 @@ agent:
 
 jobs:
   ingest:
+    nfj:
+      detail-fetch-rate-per-second: 0.25
+      cooldown-after-429: PT20M
+      max-url-backlog-before-skip: 5000
+      max-external-offers-backlog-before-skip: 5000
     exchange: ingest.jobs
     url-consumer:
       justjoin:
@@ -119,6 +124,7 @@ jobs:
       after1: PT1M
       after5: PT5M
       after30: PT30M
+      jitterFactor: 0.20
 
 eureka:
   client:

--- a/agent-crawler/src/main/resources/application.yml
+++ b/agent-crawler/src/main/resources/application.yml
@@ -67,6 +67,11 @@ agent:
 
 jobs:
   ingest:
+    nfj:
+      detail-fetch-rate-per-second: 0.25
+      cooldown-after-429: PT20M
+      max-url-backlog-before-skip: 5000
+      max-external-offers-backlog-before-skip: 5000
     exchange: ingest.jobs
     url-consumer:
       justjoin:
@@ -120,6 +125,7 @@ jobs:
       after1: PT1M
       after5: PT5M
       after30: PT30M
+      jitterFactor: 0.20
 
 eureka:
   client:


### PR DESCRIPTION
 This branch improves agent-crawler resilience when external job sources start rate limiting or temporarily fail.

  It focuses on two problem areas:

  - No Fluff Jobs
    Reduces repeated HTTP 429 storms during offer detail ingestion.
  - Solid.jobs
    Makes sitemap fetching more resilient to transient upstream failures and blocking.

  What Changed

  - NFJ detail fetch throttling
    Slowed down No Fluff Jobs detail-fetch requests and made the rate configurable.
  - NFJ source-wide cooldown after 429
    After the first 429, the crawler now activates a source-wide cooldown so it does not keep hammering NFJ with more requests.
  - Jittered retry delays
    Retry timing is now spread over time with jitter, which reduces synchronized retry waves.
  - Per-message retry expiration
    Retry queues now rely on per-message expiration instead of fixed queue-level TTLs, allowing each message to return at a slightly different time.
  - Config-driven throttling and retry settings
    The relevant NFJ and retry settings were moved into application.yml and application-aws.yml.
  - Solid sitemap fetch hardening
    Solid sitemap requests now use more browser-like headers and retry transient failures such as 429, 503, and other 5xx responses with backoff and jitter.
  - Improved Solid diagnostics
    Added better logging around sitemap failures, response status, empty responses, and possible upstream blocking.

  Expected Impact

  - Fewer repeated 429 responses from NFJ
  - Less aggressive request bursts after rate limiting starts
  - More evenly distributed retry traffic
  - Better resilience when Solid.jobs has temporary upstream issues
  - Easier diagnosis of crawler issues from logs
