### PR TITLE
CHB-48 part 3: Align Backend Retry Queues With Per-Message Expiration

### DIFF
--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/IngestMessagingProperties.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/IngestMessagingProperties.java
@@ -55,6 +55,7 @@ public class IngestMessagingProperties {
         private java.time.Duration after1 = java.time.Duration.ofMinutes(1);
         private java.time.Duration after5 = java.time.Duration.ofMinutes(5);
         private java.time.Duration after30 = java.time.Duration.ofMinutes(30);
+        private double jitterFactor = 0.20d;
     }
 
     @Getter @Setter

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitConfig.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/config/RabbitConfig.java
@@ -90,17 +90,14 @@ public class RabbitConfig {
         for (String source : p.externalOfferSources()) {
             Queue primaryQueue = QueueBuilder.durable(p.externalOffersQueue(source)).build();
             Queue retry1Queue = QueueBuilder.durable(p.externalOffersRetry1Queue(source))
-                    .withArgument("x-message-ttl", p.getRetry().getAfter1().toMillis())
                     .withArgument("x-dead-letter-exchange", p.getExchange())
                     .withArgument("x-dead-letter-routing-key", p.externalOffersRouting(source))
                     .build();
             Queue retry5Queue = QueueBuilder.durable(p.externalOffersRetry5Queue(source))
-                    .withArgument("x-message-ttl", p.getRetry().getAfter5().toMillis())
                     .withArgument("x-dead-letter-exchange", p.getExchange())
                     .withArgument("x-dead-letter-routing-key", p.externalOffersRouting(source))
                     .build();
             Queue retry30Queue = QueueBuilder.durable(p.externalOffersRetry30Queue(source))
-                    .withArgument("x-message-ttl", p.getRetry().getAfter30().toMillis())
                     .withArgument("x-dead-letter-exchange", p.getExchange())
                     .withArgument("x-dead-letter-routing-key", p.externalOffersRouting(source))
                     .build();

--- a/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/ExternalOffersRetryPublisher.java
+++ b/backend/src/main/java/com/milosz/podsiadly/backend/ingest/mq/ExternalOffersRetryPublisher.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.UUID;
 
 @Slf4j
@@ -32,6 +34,7 @@ public class ExternalOffersRetryPublisher {
         String effectiveMessageId = messageId != null && !messageId.isBlank()
                 ? messageId
                 : UUID.randomUUID().toString();
+        Long delayMs = delayForRouting(routing);
 
         rabbit.convertAndSend(props.getExchange(), routing, msg, message -> {
             var p = message.getMessageProperties();
@@ -46,11 +49,15 @@ public class ExternalOffersRetryPublisher {
             if (msgText != null) {
                 p.setHeader("x-error-message", msgText);
             }
+            if (delayMs != null) {
+                p.setExpiration(Long.toString(delayMs));
+                p.setHeader("x-delay-ms", delayMs);
+            }
             return message;
         });
 
-        log.warn("[external-offers] routed messageId={} source={} externalId={} routing={} attempt={}",
-                effectiveMessageId, msg.source(), msg.externalId(), routing, nextAttempt);
+        log.warn("[external-offers] routed messageId={} source={} externalId={} routing={} attempt={} delayMs={}",
+                effectiveMessageId, msg.source(), msg.externalId(), routing, nextAttempt, delayMs);
     }
 
     private String routingForAttempt(String source, int attempt) {
@@ -58,5 +65,41 @@ public class ExternalOffersRetryPublisher {
         if (attempt == 1) return props.externalOffersRetry5Routing(source);
         if (attempt == 2) return props.externalOffersRetry30Routing(source);
         return props.externalOffersDlqRouting(source);
+    }
+
+    private Long delayForRouting(String routing) {
+        Duration baseDelay = baseDelayForRouting(routing);
+        if (baseDelay == null) {
+            return null;
+        }
+        return jitteredDelayMs(baseDelay);
+    }
+
+    private Duration baseDelayForRouting(String routing) {
+        if (routing == null) {
+            return null;
+        }
+        if (routing.startsWith(props.getRouting().getExternalOffersRetry1())) {
+            return props.getRetry().getAfter1();
+        }
+        if (routing.startsWith(props.getRouting().getExternalOffersRetry5())) {
+            return props.getRetry().getAfter5();
+        }
+        if (routing.startsWith(props.getRouting().getExternalOffersRetry30())) {
+            return props.getRetry().getAfter30();
+        }
+        return null;
+    }
+
+    private long jitteredDelayMs(Duration baseDelay) {
+        long baseMs = Math.max(1_000L, baseDelay.toMillis());
+        double jitterFactor = Math.max(0.0d, Math.min(props.getRetry().getJitterFactor(), 0.95d));
+        if (jitterFactor == 0.0d) {
+            return baseMs;
+        }
+
+        long minMs = Math.max(1_000L, (long) Math.floor(baseMs * (1.0d - jitterFactor)));
+        long maxMs = Math.max(minMs, (long) Math.ceil(baseMs * (1.0d + jitterFactor)));
+        return ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
     }
 }

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -113,6 +113,7 @@ jobs:
       after1: PT1M
       after5: PT5M
       after30: PT30M
+      jitterFactor: 0.20
   stale:
     default-cutoff: PT96H
     nfj-cutoff: PT96H

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -114,6 +114,7 @@ jobs:
       after1: PT1M
       after5: PT5M
       after30: PT30M
+      jitterFactor: 0.20
   stale:
     default-cutoff: PT96H
     nfj-cutoff: PT96H


### PR DESCRIPTION
This change updates the backend retry topology for external offer processing so it matches the new RabbitMQ queue strategy already used by agent-crawler.

  What Changed

  - Removed queue-level x-message-ttl from external-offer retry queue declarations
  - Added per-message expiration in the backend retry publisher
  - Added jittered retry delays to avoid synchronized retry bursts
  - Added configurable jitterFactor to backend ingest retry settings
  - Updated both application.yml and application-aws.yml

  Why This Was Needed

  RabbitMQ on AWS was already using retry queues without x-message-ttl, while the backend was still trying to declare the same queues with the old TTL-based configuration.

  That mismatch caused startup failures with:

  PRECONDITION_FAILED - inequivalent arg 'x-message-ttl'

  This change makes backend queue declarations compatible with the current queue topology and removes the declaration conflict.
